### PR TITLE
Better vehicle positioning

### DIFF
--- a/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
@@ -41,6 +41,9 @@ local function updateGFX(dtReal)
 		print("Adding phys update handler hook")
 		origPhysUpdateFunc = motionSim.update
 		motionSim.update = update
+		
+		motionSim.isPhysicsStepUsed = function() return true end
+		updateCorePhysicsStepEnabled()
 	end
 
 	if v.mpVehicleType == 'R' and hydros.enableFFB then -- disable ffb if it got enabled by a reset

--- a/lua/vehicle/extensions/BeamMP/velocityVE.lua
+++ b/lua/vehicle/extensions/BeamMP/velocityVE.lua
@@ -96,7 +96,7 @@ local function onInit()
 	local cosAng = leftPos:cosAngle(backPos:cross(upPos))
 	
 	if cosAng < 0 then
-		print("Misaligned refNodes detected in vehicle"..obj:getId().."! This might cause wrong rotations or instability.")
+		print("Misaligned refNodes detected in vehicle "..obj:getId().."! This might cause wrong rotations or instability.")
 	end
 	
 	if connectedBeams[refNodes.ref] then


### PR DESCRIPTION
Gameplay changes: 
- Most cars should be a lot more stable after collisions (no more breakdancing Hoppers!)
- Vehicles should no longer be thrown into walls before teleporting during resets
- Vehicles spawning in the wrong direction should now teleport instead of rotating quickly
- F7 teleport should work better now


Detailed Changelog: 
- Allow more position and rotation error at higher velocities
- Use two different thresholds for deciding when to teleport (for small errors wait a bit for ping to catch up, for large errors or at low velocity teleport instantly
- Reset all smoothers on vehicle reset to prevent wrong movement directly after reset
- Get vehicle velocity every physics update and smooth it to reduce negative effects of vibrating refNodes
- Physics update handler now works for all props
- Fixed small typo in velocityVE console message