### PR TITLE
Fix for coupling code

### DIFF
--- a/lua/vehicle/beamstate.lua
+++ b/lua/vehicle/beamstate.lua
@@ -265,11 +265,12 @@ local function toggleCouplers()
     disableAutoCoupling()
     if v.mpVehicleType == "L" then obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'false\'," ..tostring(obj:getID())..")") end -- ////////////////////////////////////////////////// BEAMMP
   else
-    if v.mpVehicleType == "L" then obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'true\'," ..tostring(obj:getID())..")") end -- ////////////////////////////////////////////////// BEAMMP
     if isCouplerAttached() then
       detachCouplers()
+	  if v.mpVehicleType == "L" then obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'false\'," ..tostring(obj:getID())..")") end -- ////////////////////////////////////////////////// BEAMMP
     else
       activateAutoCoupling()
+	  if v.mpVehicleType == "L" then obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'true\'," ..tostring(obj:getID())..")") end -- ////////////////////////////////////////////////// BEAMMP
     end
   end
 end

--- a/lua/vehicle/extensions/BeamMP/couplerVE.lua
+++ b/lua/vehicle/extensions/BeamMP/couplerVE.lua
@@ -14,7 +14,7 @@ local function toggleCouplerState(state)
         beamstate.activateAutoCoupling()
     else
         beamstate.disableAutoCoupling()
-		beamstate.detachCouplers() --added this line since disableAutoCoupling doesn't decouple
+	beamstate.detachCouplers() --added this line since disableAutoCoupling doesn't decouple
     end
 end
 

--- a/lua/vehicle/extensions/BeamMP/couplerVE.lua
+++ b/lua/vehicle/extensions/BeamMP/couplerVE.lua
@@ -14,6 +14,7 @@ local function toggleCouplerState(state)
         beamstate.activateAutoCoupling()
     else
         beamstate.disableAutoCoupling()
+		beamstate.detachCouplers() --added this line since disableAutoCoupling doesn't decouple
     end
 end
 


### PR DESCRIPTION
Couplers state was sending incorrect information and the detach code never actually detached the coupler, there are still one scenario i've found where it fails to attach and throws a failed to export electrics error, but its not fatal and i can replicated it in SP with no MP lua active so that appears to be a game issue