### PR TITLE
Increase the launcher timeout value

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -342,7 +342,7 @@ local function onUpdate(dt)
 			else send('Up') end -- Server heartbeat
 		end
 		-- Check the launcher connection
-		if launcherConnectionTimer > 2 then
+		if launcherConnectionTimer > 10 then
 			log('M', loggerPrefix, "Connection to launcher was lost")
 			guihooks.trigger('LauncherConnectionLost')
 			disconnectLauncher(true)


### PR DESCRIPTION
Connection to the launcher will be considered "lost" after 10 seconds instead of 2.

When spawning a car the game sometimes freezes for more than 2 seconds which results in lost connection to the launcher and also the server. If connection was lost other players will appear as stationary vehicles. 
This simple fix worked for me and other people. Although I am not a Lua programmer and didn't read too much source code of this mod, so that fix could be unstable, or break other logic.