### PR TITLE
Fix Chat history bug

### DIFF
--- a/ui/modules/apps/BeamMP-Chat/app.js
+++ b/ui/modules/apps/BeamMP-Chat/app.js
@@ -1,7 +1,6 @@
 var app = angular.module('beamng.apps');
 
 let lastSentMessage = "";
-let lastReceivedMessage = "";
 
 app.directive('multiplayerchat', [function () {
 	return {
@@ -16,9 +15,6 @@ app.directive('multiplayerchat', [function () {
 
 app.controller("Chat", ['$scope', function ($scope) {
 	$scope.init = function() {
-	// try to unregister existing chatMessage listener
-	$rootScope.$$listeners.chatMessage = [] 
-
 		// Set listeners
 		var chatinput = document.getElementById("chat-input");
 		chatinput.addEventListener("mouseover", function(){ chatShown = true; showChat(); });


### PR DESCRIPTION
by @5TXdYWK

This addresses the issue caused by previous commits where once a chat message has faded out there was no way to read it again, (by hovering over the chat window).