### PR TITLE
Add hex color and background color support for chat formatting

### DIFF
--- a/ui/modules/apps/BeamMP-Chat/app.css
+++ b/ui/modules/apps/BeamMP-Chat/app.css
@@ -57,6 +57,10 @@
     background: rgba(var(--bng-cool-gray-800-rgb), 0.7);
 }
 
+.beammpChat span[style*="background-color"] {
+    text-shadow: none;
+}
+
 .beammpChat .chat-message:hover {
     border-left-color: var(--bng-orange-500);
     background: rgba(var(--bng-cool-gray-700-rgb), 0.82);

--- a/ui/modules/apps/BeamMP-Chat/app.js
+++ b/ui/modules/apps/BeamMP-Chat/app.js
@@ -9,6 +9,7 @@ let lastSentMessage = "";
 let lastMsgId = 0;
 let newChatMenu = false;
 import('/ui/lib/ext/purify.min.js')
+import('/ui/ui-vue/mods/BeamMP/shared/textFormat.js')
 app.directive('beammpChat', [function () {
 	return {
 		templateUrl: '/ui/modules/apps/BeamMP-Chat/app.html',
@@ -266,86 +267,8 @@ async function showChat() {
 
 
 function formatChatMessage(string) {
-    const blockedTags = new Set(['script', 'iframe', 'form', 'input', 'button', 'a']);
-    
-    const dangerousAttributePattern = /^(?:on.*|(?:form).*|action)$/i;
-
-    function isSafeHtml(html) {
-        const div = document.createElement('div');
-        div.innerHTML = html;
-        
-        const elements = div.getElementsByTagName('*');
-        for (let element of elements) {
-            if (blockedTags.has(element.tagName.toLowerCase())) {
-                return false;
-            }
-            
-            for (let attr of element.attributes) {
-                if (dangerousAttributePattern.test(attr.name) || 
-                    /javascript:|data:/i.test(attr.value)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    if (string.startsWith("Server: ")) {
-        const messageContent = string.substring(8);
-        if (messageContent.includes('<') && messageContent.includes('>')) {
-            if (isSafeHtml(messageContent)) {
-                return "Server: " + messageContent;
-            }
-        }
-    }
-
-    let result = '';
-    let currentText = '';
-    let classes = new Set();
-
-    string = DOMPurify.sanitize(string);
-    const tokens = string.split(/(\^.)/g);
-
-    const flush = () => {
-        if (!currentText) return;
-        const classList = Array.from(classes);
-        result += classList.length
-            ? `<span class="${classList.join(' ')}">${currentText}</span>`
-            : currentText;
-        currentText = '';
-    };
-
-    for (let i = 0; i < tokens.length; i++) {
-		const token = tokens[i];
-		const nextToken = tokens[i+1]?.trim() || '';
-		if (/^\^.$/.test(token)) {
-			flush();
-			if (token === '^r') {
-				classes.clear();
-			} else if (token === '^p') {
-				currentText += '<br>';
-			} else if (token === '^*') {
-				const cls = globalThis.beammpTextStyleMap?.[token];
-				if(cls) classes.add(cls);
-				if (iconsOrig[nextToken]) {
-					currentText = iconsOrig[nextToken].glyph
-				};
-			} else {
-				const cls = globalThis.beammpTextStyleMap?.[token];
-				if (cls?.startsWith('color-')) {
-					[...classes].forEach(c => c.startsWith('color-') && classes.delete(c));
-					classes.add(cls);
-				} else if (cls) {
-					classes.add(cls);
-				}
-			}
-		} else if (tokens[i-1]!='^*') {
-			currentText += token;
-		}
-	}
-
-    flush();
-    return result;
+	if (!globalThis.beammpFormatText) return string;
+	return globalThis.beammpFormatText(string, { allowServerHtml: true });
 }
 
 // -------------------------------------------- MESSAGE FORMATTING -------------------------------------------- //

--- a/ui/modules/apps/BeamMP-Chat/app.js
+++ b/ui/modules/apps/BeamMP-Chat/app.js
@@ -268,7 +268,10 @@ async function showChat() {
 
 function formatChatMessage(string) {
 	if (!globalThis.beammpFormatText) return string;
-	return globalThis.beammpFormatText(string, { allowServerHtml: true });
+	return globalThis.beammpFormatText(string, {
+		sanitize: globalThis.DOMPurify ? (v) => globalThis.DOMPurify.sanitize(v) : null,
+		allowServerHtml: true,
+	});
 }
 
 // -------------------------------------------- MESSAGE FORMATTING -------------------------------------------- //

--- a/ui/modules/apps/BeamMP-Chat/redesign.css
+++ b/ui/modules/apps/BeamMP-Chat/redesign.css
@@ -42,6 +42,10 @@ ul#chat-list {
     transform: translateY(-2px);
 }
 
+span[style*="background-color"] {
+    text-shadow: none;
+}
+
 .chat-message-timestamp {
     font-size: 0.75em;
     line-height: 0.75em;

--- a/ui/modules/apps/BeamMP-Chat2/app.vue
+++ b/ui/modules/apps/BeamMP-Chat2/app.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div
     class="beammpChat2"
     :class="{ 'ui-style-redesigned': useUiAppRedesign }"
@@ -44,7 +44,7 @@
           :aria-label="$tt('ui.apps.beammp.chat.moveHorizontal') || 'Move chat horizontally'"
           @click="swapHorizontal"
         >
-          ↔
+          ג†”
         </button>
         <button
 		  id="chat-vertical-button"
@@ -54,7 +54,7 @@
           :aria-label="$tt('ui.apps.beammp.chat.moveVertical') || 'Move chat vertically'"
           @click="swapVertical"
         >
-          ↕
+          ג†•
         </button>
       </form>
     </div>
@@ -65,6 +65,7 @@
 import { computed, nextTick, onMounted, onUnmounted, ref } from "vue"
 import { useBridge } from "@/bridge"
 import { BngDropdown, BngInput, ACCENTS } from "@/common/components/base"
+import { formatBeamMPText } from "/ui/ui-vue/mods/BeamMP/shared/textFormat.js"
 
 const { api, events } = useBridge()
 
@@ -103,87 +104,19 @@ const chatBoxStyle = computed(() => ({
   marginLeft: chatHorizontal.value === "right" ? "auto" : "0px",
 }))
 
-const sendButtonText = computed(() => (useUiAppRedesign.value ? "💬" : "Send"))
+const sendButtonText = computed(() => (useUiAppRedesign.value ? "נ’¬" : "Send"))
 
-function escapeHtml(value) {
-  return String(value ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/\"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-}
-
-function isSafeServerHtml(html) {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(`<div>${html}</div>`, "text/html")
-  const blockedTags = new Set(["script", "iframe", "form", "input", "button", "a"])
-  const elements = doc.body.querySelectorAll("*")
-
-  for (const element of elements) {
-    if (blockedTags.has(element.tagName.toLowerCase())) return false
-    for (const attr of element.attributes) {
-      if (/^(?:on.*|(?:form).*|action)$/i.test(attr.name)) return false
-      if (/javascript:|data:/i.test(attr.value)) return false
-    }
-  }
-  return true
+function renderChatIcon(name) {
+  const icon = globalThis.iconsOrig?.[name]
+  if (!icon?.glyph) return null
+  return { text: icon.glyph, className: "bngIcon" }
 }
 
 function formatChatMessage(value) {
-  const string = String(value ?? "")
-  if (string.startsWith("Server: ")) {
-    const messageContent = string.slice(8)
-    if (messageContent.includes("<") && messageContent.includes(">") && isSafeServerHtml(messageContent)) {
-      return `Server: ${messageContent}`
-    }
-  }
-
-  const tokens = string.split(/(\^.)/g)
-  const classes = new Set()
-  let currentText = ""
-  let result = ""
-
-  const flush = () => {
-    if (!currentText) return
-    const encoded = escapeHtml(currentText)
-    const classList = Array.from(classes).join(" ")
-    result += classList ? `<span class="${classList}">${encoded}</span>` : encoded
-    currentText = ""
-  }
-
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index]
-    const nextToken = tokens[index + 1]?.trim() || ""
-
-    if (/^\^.$/.test(token)) {
-      flush()
-      if (token === "^r") {
-        classes.clear()
-      } else if (token === "^p") {
-        result += "<br>"
-      } else if (token === "^*") {
-        const cls = globalThis.beammpTextStyleMap?.[token]
-        if (cls) classes.add(cls)
-        if (globalThis.iconsOrig?.[nextToken]) currentText = globalThis.iconsOrig[nextToken].glyph
-      } else {
-        const cls = globalThis.beammpTextStyleMap?.[token]
-        if (cls?.startsWith("color-")) {
-          for (const activeClass of [...classes]) {
-            if (activeClass.startsWith("color-")) classes.delete(activeClass)
-          }
-          classes.add(cls)
-        } else if (cls) {
-          classes.add(cls)
-        }
-      }
-    } else if (tokens[index - 1] !== "^*") {
-      currentText += token
-    }
-  }
-
-  flush()
-  return result
+  return formatBeamMPText(value, {
+    renderIcon: renderChatIcon,
+    allowServerHtml: true,
+  })
 }
 
 function storeChatMessages() {
@@ -438,6 +371,10 @@ onUnmounted(() => {
   background: rgba(var(--bng-cool-gray-800-rgb), 0.7);
 }
 
+.beammpChat2 .chat-message-content span[style*="background-color"] {
+  text-shadow: none;
+}
+
 .beammpChat2 .chat-message:hover {
   border-left-color: var(--bng-orange-500);
   background: rgba(var(--bng-cool-gray-700-rgb), 0.82);
@@ -610,7 +547,7 @@ onUnmounted(() => {
   }
 
   .beammpChat2 .send-button::before {
-    content: "↗";
+    content: "ג†—";
     font-size: 1rem;
   }
 }

--- a/ui/modules/apps/BeamMP-Session/app.js
+++ b/ui/modules/apps/BeamMP-Session/app.js
@@ -174,7 +174,9 @@ app.controller("BeamMPSessionController", ['$scope', '$mdDialog', 'Settings', fu
 
 function formatServerName(string) {
 	if (!globalThis.beammpFormatText) return string;
-	return globalThis.beammpFormatText(string);
+	return globalThis.beammpFormatText(string, {
+		sanitize: globalThis.DOMPurify ? (v) => globalThis.DOMPurify.sanitize(v) : null,
+	});
 }
 
 function isMarqueeNeeded(block, element) {

--- a/ui/modules/apps/BeamMP-Session/app.js
+++ b/ui/modules/apps/BeamMP-Session/app.js
@@ -6,6 +6,7 @@ var app = angular.module('beamng.apps');
 var mdDialog;
 var mdDialogVisible = false;
 import('/ui/lib/ext/purify.min.js')
+import('/ui/ui-vue/mods/BeamMP/shared/textFormat.js')
 app.directive('beammpSession', [function () {
 	return {
 		templateUrl: '/ui/modules/apps/BeamMP-Session/app.html',
@@ -172,52 +173,8 @@ app.controller("BeamMPSessionController", ['$scope', '$mdDialog', 'Settings', fu
 
 
 function formatServerName(string) {
-    let result = '';
-    let currentText = '';
-    let classes = new Set();
-
-	string = DOMPurify.sanitize(string);
-
-    const tokens = string.split(/(\^.)/g);
-
-    const flush = () => {
-        if (!currentText) return;
-        const classList = Array.from(classes);
-        result += classList.length
-            ? `<span class="${classList.join(' ')}">${currentText}</span>`
-            : currentText;
-        currentText = '';
-    };
-
-    for (let i = 0; i < tokens.length; i++) {
-		const token = tokens[i];
-		const nextToken = tokens[i+1]?.trim() || '';
-		if (/^\^.$/.test(token)) {
-			flush();
-			if (token === '^r') {
-				classes.clear();
-			} else if (token === '^*') {
-				const cls = globalThis.beammpTextStyleMap?.[token];
-				if(cls) classes.add(cls);
-				if (iconsOrig[nextToken]) {
-					currentText = iconsOrig[nextToken].glyph
-				};
-			} else {
-				const cls = globalThis.beammpTextStyleMap?.[token];
-				if (cls?.startsWith('color-')) {
-					[...classes].forEach(c => c.startsWith('color-') && classes.delete(c));
-					classes.add(cls);
-				} else if (cls) {
-					classes.add(cls);
-				}
-			}
-		} else if (tokens[i-1]!='^*') {
-			currentText += token;
-		}
-	}
-
-    flush();
-    return result;
+	if (!globalThis.beammpFormatText) return string;
+	return globalThis.beammpFormatText(string);
 }
 
 function isMarqueeNeeded(block, element) {

--- a/ui/ui-vue/mods/BeamMP/shared/beammpState.js
+++ b/ui/ui-vue/mods/BeamMP/shared/beammpState.js
@@ -1,5 +1,6 @@
 import { computed, ref } from "vue"
 import { useBridge } from "@/bridge"
+import { stripBeamMPFormatting } from "./textFormat.js"
 
 // useBridge is a Vue composable, so initialise it from useBeamMPState() while
 // component setup is active, then retain its API for this shared state module.
@@ -221,7 +222,7 @@ function saveFilters() {
 }
 
 function stripCustomFormatting(name = "") {
-  return name.replace(/\^[0-9a-frlmnop*]/gi, "")
+  return stripBeamMPFormatting(name)
 }
 
 function smoothMapName(map = "") {

--- a/ui/ui-vue/mods/BeamMP/shared/textFormat.js
+++ b/ui/ui-vue/mods/BeamMP/shared/textFormat.js
@@ -1,0 +1,170 @@
+import { BEAMMP_TEXT_STYLE_MAP } from "./constants.js"
+
+const HEX = "[0-9a-fA-F]{6}"
+const TOKEN_PATTERN = new RegExp(`(\\^@#${HEX}|\\^#${HEX}|\\^.)`, "g")
+const HEX_FG_PATTERN = new RegExp(`^\\^#${HEX}$`)
+const HEX_BG_PATTERN = new RegExp(`^\\^@#${HEX}$`)
+const SIMPLE_TOKEN_PATTERN = /^\^.$/
+const STRIP_PATTERN = new RegExp(`\\^@#${HEX}|\\^#${HEX}|\\^[0-9a-frlmnop*]`, "gi")
+
+const SERVER_PREFIX = "Server: "
+const BLOCKED_TAGS = new Set(["script", "iframe", "form", "input", "button", "a"])
+const DANGEROUS_ATTRIBUTE_PATTERN = /^(?:on.*|(?:form).*|action)$/i
+const DANGEROUS_VALUE_PATTERN = /javascript:|data:/i
+
+export function escapeHtml(value = "") {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+export function isSafeServerHtml(html) {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(`<div>${html}</div>`, "text/html")
+
+  for (const element of doc.body.querySelectorAll("*")) {
+    if (BLOCKED_TAGS.has(element.tagName.toLowerCase())) return false
+    for (const attr of element.attributes) {
+      if (DANGEROUS_ATTRIBUTE_PATTERN.test(attr.name)) return false
+      if (DANGEROUS_VALUE_PATTERN.test(attr.value)) return false
+    }
+  }
+  return true
+}
+
+export function stripBeamMPFormatting(value = "") {
+  return String(value).replace(STRIP_PATTERN, "")
+}
+
+export function formatBeamMPText(value, options = {}) {
+  const {
+    escape = escapeHtml,
+    renderIcon = null,
+    allowServerHtml = false,
+    styleMap = BEAMMP_TEXT_STYLE_MAP,
+  } = options
+
+  const raw = String(value ?? "")
+  if (!raw) return ""
+
+  if (allowServerHtml && raw.startsWith(SERVER_PREFIX)) {
+    const body = raw.slice(SERVER_PREFIX.length)
+    if (body.includes("<") && body.includes(">") && isSafeServerHtml(body)) {
+      return `${SERVER_PREFIX}${body}`
+    }
+  }
+
+  const tokens = raw.split(TOKEN_PATTERN)
+  const classes = new Set()
+  let result = ""
+  let currentText = ""
+  let hexColor = null
+  let hexBackground = null
+
+  const clearColorClasses = () => {
+    for (const className of [...classes]) {
+      if (className.startsWith("color-")) classes.delete(className)
+    }
+  }
+
+  const flush = () => {
+    if (!currentText) return
+
+    const classList = Array.from(classes)
+    let attributes = classList.length ? ` class="${classList.join(" ")}"` : ""
+
+    let style = ""
+    if (hexColor) style += `color:${hexColor};`
+    if (hexBackground) style += `background-color:${hexBackground};`
+    if (style) attributes += ` style="${style}"`
+
+    const encoded = escape(currentText)
+    result += attributes ? `<span${attributes}>${encoded}</span>` : encoded
+    currentText = ""
+  }
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+
+    if (HEX_BG_PATTERN.test(token)) {
+      flush()
+      hexBackground = token.slice(2)
+      continue
+    }
+
+    if (HEX_FG_PATTERN.test(token)) {
+      flush()
+      clearColorClasses()
+      hexColor = token.slice(1)
+      continue
+    }
+
+    if (!SIMPLE_TOKEN_PATTERN.test(token)) {
+      currentText += token
+      continue
+    }
+
+    flush()
+
+    if (token === "^r") {
+      classes.clear()
+      hexColor = null
+      hexBackground = null
+      continue
+    }
+
+    if (token === "^p") {
+      result += "<br>"
+      continue
+    }
+
+    if (token === "^*") {
+      const next = tokens[index + 1] ?? ""
+      const trimmed = next.trim()
+
+      let icon = trimmed && renderIcon ? renderIcon(trimmed) : null
+      let remainder = ""
+
+      if (!icon && trimmed && renderIcon) {
+        const firstWord = trimmed.split(/\s+/)[0]
+        if (firstWord !== trimmed) {
+          icon = renderIcon(firstWord)
+          if (icon) remainder = next.slice(next.indexOf(firstWord) + firstWord.length)
+        }
+      }
+
+      if (!icon) continue
+
+      if (icon.html) {
+        result += icon.html
+      } else if (icon.text) {
+        if (icon.className) classes.add(icon.className)
+        currentText = icon.text
+        flush()
+        if (icon.className) classes.delete(icon.className)
+      }
+
+      index += 1
+      if (remainder) currentText += remainder
+      continue
+    }
+
+    const mappedClass = styleMap?.[token]
+    if (mappedClass?.startsWith("color-")) {
+      clearColorClasses()
+      classes.add(mappedClass)
+      hexColor = null
+    } else if (mappedClass) {
+      classes.add(mappedClass)
+    }
+  }
+
+  flush()
+  return result
+}
+
+globalThis.beammpFormatText = formatBeamMPText
+globalThis.beammpStripFormatting = stripBeamMPFormatting

--- a/ui/ui-vue/mods/BeamMP/shared/textFormat.js
+++ b/ui/ui-vue/mods/BeamMP/shared/textFormat.js
@@ -41,6 +41,7 @@ export function stripBeamMPFormatting(value = "") {
 
 export function formatBeamMPText(value, options = {}) {
   const {
+    sanitize = null,
     escape = escapeHtml,
     renderIcon = null,
     allowServerHtml = false,
@@ -57,7 +58,7 @@ export function formatBeamMPText(value, options = {}) {
     }
   }
 
-  const tokens = raw.split(TOKEN_PATTERN)
+  const tokens = (sanitize ? String(sanitize(raw)) : raw).split(TOKEN_PATTERN)
   const classes = new Set()
   let result = ""
   let currentText = ""
@@ -81,7 +82,7 @@ export function formatBeamMPText(value, options = {}) {
     if (hexBackground) style += `background-color:${hexBackground};`
     if (style) attributes += ` style="${style}"`
 
-    const encoded = escape(currentText)
+    const encoded = sanitize ? currentText : escape(currentText)
     result += attributes ? `<span${attributes}>${encoded}</span>` : encoded
     currentText = ""
   }

--- a/ui/ui-vue/mods/BeamMP/views/BeamMPServersView.vue
+++ b/ui/ui-vue/mods/BeamMP/views/BeamMPServersView.vue
@@ -298,7 +298,7 @@ import { BngButton, BngInput } from "@/common/components/base"
 import { vBngTextInput } from "@/common/directives"
 import { useBeamMPState } from "../shared/beammpState.js"
 import { icons as bngIcons } from "/ui/ui-vue/src/assets/fonts/bngIcons/bngIcons.js"
-import { BEAMMP_TEXT_STYLE_MAP } from "../shared/constants.js"
+import { formatBeamMPText } from "../shared/textFormat.js"
 
 const route = useRoute()
 const filtersRail = ref(null)
@@ -542,79 +542,18 @@ function onServersScroll(event) {
   }
 }
 
-function escapeHtml(value = "") {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
+function renderServerTitleIcon(name) {
+  const icon = bngIcons?.[name]
+  if (!icon?.fileSvg) return null
+  return {
+    html: `<img class="server-title-icon" src="/ui/ui-vue/src/assets/fonts/bngIcons/${icon.fileSvg}" alt="" aria-hidden="true" />`,
+  }
 }
 
 function serverTitleMarkup(server) {
-  const raw = String(server?.sname || server?.strippedName || "")
-  if (!raw) return ""
-
-  const tokens = raw.split(/(\^.)/g)
-  let result = ""
-  let currentText = ""
-  const activeClasses = new Set()
-
-  const flushText = () => {
-    if (!currentText) return
-    const classList = Array.from(activeClasses)
-    const encoded = escapeHtml(currentText)
-    result += classList.length
-      ? `<span class="${classList.join(" ")}">${encoded}</span>`
-      : encoded
-    currentText = ""
-  }
-
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index]
-    const nextToken = (tokens[index + 1] || "").trim()
-
-    if (/^\^.$/.test(token)) {
-      flushText()
-
-      if (token === "^r") {
-        activeClasses.clear()
-        continue
-      }
-
-      if (token === "^p") {
-        result += "<br>"
-        continue
-      }
-
-      if (token === "^*") {
-        const icon = bngIcons?.[nextToken]
-        if (icon?.fileSvg) {
-          result += `<img class="server-title-icon" src="/ui/ui-vue/src/assets/fonts/bngIcons/${icon.fileSvg}" alt="" aria-hidden="true" />`
-        }
-        index += 1
-        continue
-      }
-
-      const mappedClass = BEAMMP_TEXT_STYLE_MAP[token]
-      if (mappedClass?.startsWith("color-")) {
-        for (const className of [...activeClasses]) {
-          if (className.startsWith("color-")) {
-            activeClasses.delete(className)
-          }
-        }
-        activeClasses.add(mappedClass)
-      } else if (mappedClass) {
-        activeClasses.add(mappedClass)
-      }
-      continue
-    }
-
-    currentText += token
-  }
-
-  flushText()
-  return result
+  return formatBeamMPText(String(server?.sname || server?.strippedName || ""), {
+    renderIcon: renderServerTitleIcon,
+  })
 }
 
 function playerNames(server) {


### PR DESCRIPTION
Adds ^#RRGGBB for custom text color and ^@#RRGGBB for background color in chat.
All existing formatting codes (^0-^f, ^l, ^m, ^n, ^o, ^r) remain fully supported.

- Chat: full hex color and background support
- Session and launcher: hex color only
- Used $sce.trustAsHtml in the launcher to allow inline styles through Angular's ng-bind-html
- Chat redesign: disabled text-shadow on highlighted text