### PR TITLE
GC optimization for positionVE and velocityVE

### DIFF
--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -9,6 +9,7 @@ local M = {}
 local abs = math.abs
 local min = math.min
 local max = math.max
+local sqrt = math.sqrt
 
 
 
@@ -25,9 +26,10 @@ end
 
 function vectorSmoothing:get(sample, dt)
   local st = self.state
-  local dif = sample - st
-  st = st + dif * min(self.rate * dt, 1)
-  self.state = st
+  local rate = min(self.rate * dt, 1)
+  st.x = st.x + (sample.x - st.x)*rate
+  st.y = st.y + (sample.y - st.y)*rate
+  st.z = st.z + (sample.z - st.z)*rate
   return st
 end
 
@@ -101,17 +103,20 @@ local lastRacc = nil
 local tpTimer = 0
 
 local remoteData = {
-	pos = nil,
+	pos = vec3(0,0,0),
 	vel = vec3(0,0,0),
 	acc = vec3(0,0,0),
 	rot = quat(0,0,0,0),
 	rvel = vec3(0,0,0),
 	racc = vec3(0,0,0),
-	timer = 0,
+	timer = -1,
 	timeOffset = 0,
 	recTime = 0,
 	localSimspeed = 1
 }
+
+local currentVel = vec3(0,0,0)
+local currentRvel = vec3(0,0,0)
 
 local smoothVel = vec3(0,0,0)
 local smoothRvel = vec3(0,0,0)
@@ -121,6 +126,33 @@ local physHandlerAdded = false
 local debugDrawer = obj.debugDrawProxy
 
 local simSpeedReal = 1
+
+local stringBuffer = require("string.buffer")
+local posSendBuffer = stringBuffer.new()
+local posSendTable = {
+	pos = {0, 0, 0},
+	vel = {0, 0, 0},
+	rot = {0, 0, 0, 0},
+	rvel = {0, 0, 0},
+	tim = 0,
+	ping = 0
+}
+
+-- Cached variables for calculations
+local dir = vec3()
+local dirUp = vec3()
+local rot = quat()
+local cog = vec3()
+local rvel = vec3()
+local pos = vec3()
+local vel = vec3()
+
+local vehRot = quat()
+local vehRvel = vec3()
+local vehRacc = vec3()
+local vehPos = vec3()
+local vehVel = vec3()
+local vehAcc = vec3()
 -- ============= VARIABLES =============
 
 
@@ -136,22 +168,13 @@ end
 
 -- Limit vector length
 local function limitVecLength(vec, length)
-	local vecLength = vec:length()
-	
-	if vecLength > length then
-		return vec*(length/vecLength)
+	local sqLength = vec:squaredLength()
+
+	if sqLength > length*length then
+		vec:setScaled(length/sqrt(sqLength))
 	end
-	
+
 	return vec
-end
-
-
-
--- Rotate the vehicle relative to its current rotation
-local function rotateVehicle(rot)
-	for _, n in pairs(v.data.nodes) do
-		obj:setNodePosition(n.cid, vec3(obj:getNodePosition(n.cid)):rotated(rot):toFloat3())
-	end
 end
 
 
@@ -168,18 +191,18 @@ local function onReset()
 	remoteRaccSmoother:reset()
 	accErrorSmoother:reset()
 	raccErrorSmoother:reset()
-	
+
 	lastVehVel = nil
 	lastVehRvel = nil
 
 	lastAcc = nil
 	lastRacc = nil
 
-	smoothVel = vec3(0,0,0)
-	smoothRvel = vec3(0,0,0)
-	remoteData.acc = vec3(0,0,0)
-	remoteData.racc = vec3(0,0,0)
-	remoteData.timer = 0
+	smoothVel:set(0,0,0)
+	smoothRvel:set(0,0,0)
+	remoteData.acc:set(0,0,0)
+	remoteData.racc:set(0,0,0)
+	remoteData.timer = -1
 	framesSinceReset = 0
 end
 
@@ -187,8 +210,11 @@ end
 
 local function update(dtSim)
 	-- Smooth vehicle velocity to prevent vibrating
-	smoothVel = localVelSmoother:get(vec3(obj:getVelocity()), dtSim)
-	smoothRvel = localRvelSmoother:get(vec3(obj:getPitchAngularVelocity(), obj:getRollAngularVelocity(), obj:getYawAngularVelocity()), dtSim)
+	currentVel.x, currentVel.y, currentVel.z = obj:getVelocityXYZ()
+	currentRvel.y, currentRvel.x, currentRvel.z = obj:getRollPitchYawAngularVelocity()
+
+	smoothVel = localVelSmoother:get(currentVel, dtSim)
+	smoothRvel = localRvelSmoother:get(currentRvel, dtSim)
 end
 
 
@@ -200,10 +226,6 @@ local function updateRemoteData()
 	if lastMailboxVersion ~= currentMailBoxVersion then
 		local jsonData = obj:getLastMailbox(mailBoxName)
 		local pr = jsonDecode(jsonData)
-		local pos  = vec3(pr.pos)
-		local vel  = vec3(pr.vel)
-		local rot  = quat(pr.rot)
-		local rvel = vec3(pr.rvel)
 		local tim  = pr.tim
 		local ping = pr.ping
 		local simspeedfraction = 1/simSpeedReal
@@ -213,12 +235,23 @@ local function updateRemoteData()
 
 		local remoteDT = max(tim - remoteData.timer, 0.001)
 
-		remoteData.pos = pos
-		remoteData.rot = rot
-		remoteData.acc = limitVecLength((vel - remoteData.vel)/remoteDT, maxAcc)
-		remoteData.racc = limitVecLength((rvel - remoteData.rvel)/remoteDT, maxRacc)
-		remoteData.vel = vel*simspeedfraction
-		remoteData.rvel = rvel*simspeedfraction
+		vel:set(pr.vel[1], pr.vel[2], pr.vel[3])
+		rvel:set(pr.rvel[1], pr.rvel[2], pr.rvel[3])
+
+		remoteData.pos:set(pr.pos[1], pr.pos[2], pr.pos[3])
+		remoteData.rot:set(pr.rot[1], pr.rot[2], pr.rot[3], pr.rot[4])
+		remoteData.acc:set(vel)
+		remoteData.acc:setSub(remoteData.vel)
+		remoteData.acc:setScaled(1/remoteDT)
+		limitVecLength(remoteData.acc, maxAcc)
+		remoteData.racc:set(rvel)
+		remoteData.acc:setSub(remoteData.rvel)
+		remoteData.acc:setScaled(1/remoteDT)
+		limitVecLength(remoteData.acc, maxRacc)
+		remoteData.vel:set(vel)
+		remoteData.vel:setScaled(simspeedfraction)
+		remoteData.rvel:set(rvel)
+		remoteData.rvel:setScaled(simspeedfraction)
 		remoteData.timer = tim
 		remoteData.timeOffset = timer-tim - ownPing/2 - ping/2 - lastDT
 		remoteData.recTime = timer
@@ -238,20 +271,39 @@ local function updateGFX(dt)
 
 
 	-- If there is no received data, or data is older than timeout, do nothing
-	if not remoteData.pos or (timer-remoteData.recTime) > packetTimeout then return end
+	if remoteData.timer < 0 or (timer-remoteData.recTime) > packetTimeout then return end
 
 	-- Local vehicle data
-	local vehRot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
-	local vehRvel = smoothRvel:rotated(vehRot)
-	local vehRacc = vehRvel-(lastVehRvel or vehRvel)
-	
-	local cog = velocityVE.cogRel:rotated(vehRot)
-	local vehPos = vec3(obj:getPosition()) + cog
-	local vehVel = smoothVel + cog:cross(vehRvel)
-	local vehAcc = vehVel-(lastVehVel or vehVel)
+	dir:set(obj:getDirectionVectorXYZ())
+	dir:setScaled(-1)
+	dirUp:set(obj:getDirectionVectorUpXYZ())
+	vehRot:setFromDir(dir, dirUp)
+	vehRvel:set(smoothRvel)
+	vehRvel:setRotate(vehRot)
+	if lastVehRvel then
+		vehRacc:set(vehRvel)
+		vehRacc:setSub(lastVehRvel)
+		lastVehRvel:set(vehRvel)
+	else
+		vehRacc:set(0,0,0)
+		lastVehRvel = vehRvel:copy()
+	end
 
-	lastVehVel = vehVel
-	lastVehRvel = vehRvel
+	cog:set(velocityVE.cogRel)
+	cog:setRotate(vehRot)
+	vehPos:set(obj:getPositionXYZ())
+	vehPos:setAdd(cog)
+	vehVel:set(smoothVel)
+	cog:setCross(cog, vehRvel)
+	vehVel:setAdd(cog)
+	if lastVehVel then
+		vehAcc:set(vehVel)
+		vehAcc:setSub(lastVehVel)
+		lastVehVel:set(vehVel)
+	else
+		vehAcc:set(0,0,0)
+		lastVehVel = vehVel:copy()
+	end
 
 	-- Smoothed difference between local and remote timestamps
 	local timeOffset = timeOffsetSmoother:get(remoteData.timeOffset, dt)
@@ -274,28 +326,32 @@ local function updateGFX(dt)
 	local remoteRacc = remoteRaccSmoother:get(remoteData.racc, smootherDT)
 
 	-- Use received position, and smoothed velocity and acceleration to predict vehicle position
-	local pos = remoteData.pos + remoteVel*predictTime + 0.5*remoteAcc*predictTime*predictTime
-	local vel = remoteVel + remoteAcc*predictTime
-	local rotAdd = remoteRvel*predictTime + 0.5*remoteRacc*predictTime*predictTime
-	local rot = remoteData.rot * quatFromEuler(rotAdd.x, rotAdd.y, rotAdd.z)
-	local rvel = remoteRvel + remoteRacc*predictTime
+	local predictTimeAcc = 0.5*predictTime*predictTime
+	pos:set(push3(remoteData.pos) + push3(remoteVel)*predictTime + push3(remoteAcc)*predictTimeAcc)
+	vel:set(push3(remoteVel) + push3(remoteAcc)*predictTime)
+	local rotAdd = push3(remoteRvel)*predictTime + push3(remoteRacc)*predictTimeAcc
+	rot:set(remoteData.rot * quatFromEuler(rotAdd:xyz()))
+	rvel:set(push3(remoteRvel) + push3(remoteRacc)*predictTime)
 
 	--[[
 	-- Debug
-	debugDrawer:drawSphere(0.3, remoteData.pos:toFloat3(), color(0,0,255,200))
-	debugDrawer:drawLine(remoteData.pos:toFloat3(), (remoteData.pos + vec3(0,-5,0):rotated(remoteData.rot)):toFloat3(), color(0,0,255,200))
-	debugDrawer:drawSphere(0.3, pos:toFloat3(), color(0,255,0,200))
-	debugDrawer:drawLine(pos:toFloat3(), (pos + vec3(0,-5,0):rotated(rot)):toFloat3(), color(0,255,0,200))
-	debugDrawer:drawSphere(0.3, vehPos:toFloat3(), color(255,0,0,200))
-	debugDrawer:drawLine(vehPos:toFloat3(), (vehPos + vec3(0,-5,0):rotated(vehRot)):toFloat3(), color(255,0,0,200))
-	debugDrawer:drawText(pos:toFloat3(), color(0,0,0,255), string.format("Prediction: %.0f ms", predictTime*1000))
+	debugDrawer:drawSphere(0.3, remoteData.pos, color(0,0,255,200))
+	debugDrawer:drawLine(remoteData.pos, (remoteData.pos + vec3(0,-5,0):rotated(remoteData.rot)), color(0,0,255,200))
+	debugDrawer:drawSphere(0.3, pos, color(0,255,0,200))
+	debugDrawer:drawLine(pos, (pos + vec3(0,-5,0):rotated(rot)), color(0,255,0,200))
+	debugDrawer:drawSphere(0.3, vehPos, color(255,0,0,200))
+	debugDrawer:drawLine(vehPos, (vehPos + vec3(0,-5,0):rotated(vehRot)), color(255,0,0,200))
+	debugDrawer:drawText(pos, color(0,0,0,255), string.format("Prediction: %.0f ms", predictTime*1000))
 	--]]
 
 	-- Error correction
 	local posError = pos - vehPos
 	local rotErrorQuat = vehRot:inversed() * rot
 	local rotError = rotErrorQuat:toEulerYXZ()
-	rotError = vec3(rotError.y, rotError.z, rotError.x)
+	local x = rotError.x
+	rotError.x = rotError.y
+	rotError.y = rotError.z
+	rotError.z = x
 	
 	-- Calculate teleport thresholds
 	local maxVel = tpVelSmoother:get(max(vel:length(), vehVel:length()), dt)
@@ -303,17 +359,17 @@ local function updateGFX(dt)
 	local tpDist2 = tpDistAdd + maxVel*tpDistMul2
 	
 	-- Debug for teleport distances
-	--debugDrawer:drawSphere(tpDist1, vehPos:toFloat3(), color(0,0,255,50))
-	--debugDrawer:drawSphere(tpDist2, vehPos:toFloat3(), color(255,0,0,50))
+	--debugDrawer:drawSphere(tpDist1, vehPos, color(0,0,255,50))
+	--debugDrawer:drawSphere(tpDist2, vehPos, color(255,0,0,50))
 	
 	local maxRvel = tpRvelSmoother:get(max(rvel:length(), vehRvel:length()), dt)
 	local tpRot1 = tpRotAdd + maxRvel*tpRotMul1
 	local tpRot2 = tpRotAdd + maxRvel*tpRotMul2
 	
-	local posErrorLen = posError:length()
-	local rotErrorLen = rotError:length()
+	local posErrorLenSq = posError:squaredLength()
+	local rotErrorLenSq = rotError:squaredLength()
 	
-	if posErrorLen > tpDist1 or rotErrorLen > tpRot1 then
+	if posErrorLenSq > tpDist1*tpDist1 or rotErrorLenSq > tpRot1*tpRot1 then
 		tpTimer = tpTimer + dt
 	else
 		tpTimer = 0
@@ -321,13 +377,15 @@ local function updateGFX(dt)
 
 	-- If instant teleport distance or teleport timer exceeded, teleport
 	if framesSinceReset > 5 then -- wating 6 frames then always teleporting the 6th frame makes reseting/recovering a remote vehicle at speed teleport much more consistent, maybe the smoothers catching up?
-		if framesSinceReset == 6 or tpTimer > (tpDelayAdd + abs(predictTime)) or posErrorLen > tpDist2 or rotErrorLen > tpRot2 then
+		if framesSinceReset == 6 or tpTimer > (tpDelayAdd + abs(predictTime)) or posErrorLenSq > tpDist2*tpDist2 or rotErrorLenSq > tpRot2*tpRot2 then
 			local predictTime = predictTime + dt -- add one frame so postion is correct when arriving in GE
 			-- Use received position, and smoothed velocity and acceleration to predict vehicle position
-			local pos = remoteData.pos + remoteVel*predictTime + 0.5*remoteAcc*predictTime*predictTime
-			local vel = remoteVel + remoteAcc*predictTime
-			local rotAdd = remoteRvel*predictTime + 0.5*remoteRacc*predictTime*predictTime
-			local rot = remoteData.rot * quatFromEuler(rotAdd.x, rotAdd.y, rotAdd.z)
+			local predictTimeAcc = 0.5*predictTime*predictTime
+			pos:set(push3(remoteData.pos) + push3(remoteVel)*predictTime + push3(remoteAcc)*predictTimeAcc)
+			vel:set(push3(remoteVel) + push3(remoteAcc)*predictTime)
+			local rotAdd = push3(remoteRvel)*predictTime + push3(remoteRacc)*predictTimeAcc
+			rot:set(remoteData.rot * quatFromEuler(rotAdd:xyz()))
+			rvel:set(push3(remoteRvel) + push3(remoteRacc)*predictTime)
 			-- Subtract COG offset because setPosition works relative to refNode
 			local tpPos = pos - velocityVE.cogRel:rotated(rot)
 
@@ -342,8 +400,8 @@ local function updateGFX(dt)
 			remoteVelSmoother:set(remoteData.vel)
 			remoteRvelSmoother:set(remoteData.rvel)
 	
-			remoteData.acc = vec3(0,0,0)
-			remoteData.racc = vec3(0,0,0)
+			remoteData.acc:set(0,0,0)
+			remoteData.racc:set(0,0,0)
 			remoteAccSmoother:reset()
 			remoteRaccSmoother:reset()
 	
@@ -351,37 +409,43 @@ local function updateGFX(dt)
 	
 			accErrorSmoother:reset()
 			raccErrorSmoother:reset()
-	
+
 			return
 		end
 	end
 
-	local velError = vel - vehVel
+	local velError = vel
+	velError:setSub(vehVel)
 	local accError = accErrorSmoother:get((lastAcc or vehAcc) - vehAcc, dt)
 	--print("AccError: "..tostring(accError:length()/dt))
 
-	local rvelError = rvel - vehRvel
+	local rvelError = rvel
+	rvelError:setSub(vehRvel)
 	local raccError = raccErrorSmoother:get((lastRacc or vehRacc) - vehRacc, dt)
 	--print("RaccError: "..tostring(raccError:length()/dt))
 
-	local targetAcc = limitVecLength((velError + posError*posCorrectMul)*min(posForceMul*dt,1), maxPosForce*dt)
-	local targetRacc = limitVecLength((rvelError + rotError*rotCorrectMul)*min(rotForceMul*dt,1), maxRotForce*dt)
+	local targetAcc = ((push3(velError) + push3(posError)*posCorrectMul)*min(posForceMul*dt,1)):copy()
+	limitVecLength(targetAcc, maxPosForce*dt)
+	local targetRacc = ((push3(rvelError) + push3(rotError)*rotCorrectMul)*min(rotForceMul*dt,1)):copy()
+	limitVecLength(targetRacc, maxRotForce*dt)
 
-	local targetAccMul = 1-min(max(targetAcc:dot(accError)/(targetAcc:squaredLength()+maxAccError*maxAccError*dt),0),1)
+	local targetAccMul = 1-min(max(push3(targetAcc):dot(accError)/(targetAcc:squaredLength()+maxAccError*maxAccError*dt),0),1)
 	--print("Force multiplier: "..targetAccMul)
-	targetAcc = targetAcc*targetAccMul
+	targetAcc:setScaled(targetAccMul)
 
-	local targetRaccMul = 1-min(max(targetRacc:dot(raccError)/(targetRacc:squaredLength()+maxRaccError*maxRaccError*dt),0),1)
+	local targetRaccMul = 1-min(max(push3(targetRacc):dot(raccError)/(targetRacc:squaredLength()+maxRaccError*maxRaccError*dt),0),1)
 	--print("Rotation force multiplier: "..targetRaccMul)
-	targetRacc = targetRacc*targetRaccMul
+	targetRacc:setScaled(targetRaccMul)
 
 	--print("targetAcc: "..targetAcc:length())
 	--print("targetRacc: "..targetRacc:length())
 	if framesSinceReset > 5 then
-		if targetRacc:length() > minRotForce or vehVel:length() > 1 then
+		if targetRacc:squaredLength() > minRotForce*minRotForce or vehVel:squaredLength() > 1 then
 			velocityVE.addAngularVelocity(targetAcc.x, targetAcc.y, targetAcc.z, targetRacc.x, targetRacc.y, targetRacc.z)
-		elseif targetAcc:length() > minPosForce then
+			--profiler:add("velocityVE.addAngularVelocity")
+		elseif targetAcc:squaredLength() > minPosForce*minPosForce then
 			velocityVE.addVelocity(targetAcc.x, targetAcc.y, targetAcc.z)
+			--profiler:add("velocityVE.addVelocity")
 		end
 	end
 
@@ -393,26 +457,44 @@ end
 
 local function getVehicleRotation()
 	-- this attempts to send a full table of nan if there are several rapid instability causing VE lua to break after next vehicle reload, seems to be caused by a game issue
-	local rot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
-	local rvel = smoothRvel:rotated(rot)
-	
-	local cog = velocityVE.cogRel:rotated(rot)
-	local pos = vec3(obj:getPosition()) + cog
-	local vel = smoothVel + cog:cross(rvel)
+	dir:set(obj:getDirectionVectorXYZ())
+	dir:setScaled(-1)
+	dirUp:set(obj:getDirectionVectorUpXYZ())
+	rot:setFromDir(dir, dirUp)
+	rvel:set(smoothRvel)
+	rvel:setRotate(rot)
+
+	cog:set(velocityVE.cogRel)
+	cog:setRotate(rot)
+	pos:set(obj:getPositionXYZ())
+	pos:setAdd(cog)
+	vel:set(smoothVel)
+	cog:setCross(cog, rvel)
+	vel:setAdd(cog)
 	if vel ~= vel then log('E','getVehicleRotation', 'skipped invalid velocity values') return end
 
-	vel = vel * simSpeedReal
-	rvel = rvel * simSpeedReal
+	vel:setScaled(simSpeedReal)
+	rvel:setScaled(simSpeedReal)
 
-	local tempTable = {
-		pos = {pos.x, pos.y, pos.z},
-		vel = {vel.x, vel.y, vel.z},
-		rot = {rot.x, rot.y, rot.z, rot.w},
-		rvel = {rvel.x, rvel.y, rvel.z},
-		tim = timer,
-		ping = ownPing + lastDT
-	}
-	obj:queueGameEngineLua("positionGE.sendVehiclePosRot(\'"..jsonEncode(tempTable).."\', "..obj:getID()..")") -- Send it
+	posSendTable.pos[1] = pos.x
+	posSendTable.pos[2] = pos.y
+	posSendTable.pos[3] = pos.z
+	posSendTable.vel[1] = vel.x
+	posSendTable.vel[2] = vel.y
+	posSendTable.vel[3] = vel.z
+	posSendTable.rot[1] = rot.x
+	posSendTable.rot[2] = rot.y
+	posSendTable.rot[3] = rot.z
+	posSendTable.rot[4] = rot.w
+	posSendTable.rvel[1] = rvel.x
+	posSendTable.rvel[2] = rvel.y
+	posSendTable.rvel[3] = rvel.z
+	posSendTable.tim = timer
+	posSendTable.ping = ownPing + lastDT
+
+	posSendBuffer:reset()
+	posSendBuffer:put("positionGE.sendVehiclePosRot(\'", jsonEncode(posSendTable), "\', ", obj:getID(), ")")
+	obj:queueGameEngineLua(posSendBuffer) -- Send it
 end
 
 

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -204,6 +204,7 @@ local function onReset()
 	remoteData.racc:set(0,0,0)
 	remoteData.timer = -1
 	framesSinceReset = 0
+	tpTimer = 0
 end
 
 
@@ -245,9 +246,9 @@ local function updateRemoteData()
 		remoteData.acc:setScaled(1/remoteDT)
 		limitVecLength(remoteData.acc, maxAcc)
 		remoteData.racc:set(rvel)
-		remoteData.acc:setSub(remoteData.rvel)
-		remoteData.acc:setScaled(1/remoteDT)
-		limitVecLength(remoteData.acc, maxRacc)
+		remoteData.racc:setSub(remoteData.rvel)
+		remoteData.racc:setScaled(1/remoteDT)
+		limitVecLength(remoteData.racc, maxRacc)
 		remoteData.vel:set(vel)
 		remoteData.vel:setScaled(simspeedfraction)
 		remoteData.rvel:set(rvel)

--- a/lua/vehicle/extensions/BeamMP/velocityVE.lua
+++ b/lua/vehicle/extensions/BeamMP/velocityVE.lua
@@ -24,29 +24,48 @@ M.cogRel = vec3(0,0,0)
 
 local refNode = v.data.refNodes[0].ref
 
+-- Cached variables for calculations
+local dir = vec3()
+local dirUp = vec3()
+local rot = quat()
+local cog = vec3()
+local rvel = vec3()
+local vel = vec3()
+
+local vehRvel = vec3()
+local vehVel = vec3()
+
+local zeroVec = vec3(0,0,0)
+local forceVec = vec3()
+
 -- Calculate center of gravity from connected nodes
 local function calcCOG()
 	
 	--print("Calculating COG "..obj:getId())
 	
 	local totalMass = 0
-	local cog = vec3(0,0,0)
+	cog:set(0,0,0)
 	
 	for i = 1, #nodes do
 		local node = nodes[i]
 		local nid = node[1]
 		local nodeMass = node[2]
 		local nodePos = obj:getNodePosition(nid)
+		nodePos:setScaled(nodeMass)
 		
-		cog:setAdd(nodePos*nodeMass)
+		cog:setAdd(nodePos)
 		
 		totalMass = totalMass + nodeMass
 	end
 	
 	cog:setScaled(1/totalMass)
 	
-	local rot = quatFromDir(-obj:getDirectionVector(), obj:getDirectionVectorUp())
-	M.cogRel = cog:rotated(rot:inversed())
+	dir:set(obj:getDirectionVectorXYZ())
+	dir:setScaled(-1)
+	dirUp:set(obj:getDirectionVectorUpXYZ())
+	rot:setFromDir(dir, dirUp)
+	rot:inverse()
+	M.cogRel = cog:rotated(rot)
 end
 
 -- Find all nodes that are connected to the parent node
@@ -66,18 +85,21 @@ local function findConnectedNodes()
 	nodeStack[1] = parentNode
 	visited[parentNode] = true
 	
-	local cog = vec3(0,0,0)
+	cog:set(0,0,0)
 	local totalMass = 0
+
+	local refClusterID = obj:getNodeCluster(refNode)
 	
 	while stackIdx > 0 do
 		local node = nodeStack[stackIdx]
 		local nodeMass = obj:getNodeMass(node)
 		local nodePos = obj:getNodePosition(node)
+		nodePos:setScaled(nodeMass)
 		
 		nodes[#nodes+1] = {node, nodeMass*physicsFPS}
 		connected[node] = 1
 		
-		cog:setAdd(nodePos*nodeMass)
+		cog:setAdd(nodePos)
 		totalMass = totalMass + nodeMass
 		
 		nodeStack[stackIdx] = nil
@@ -101,7 +123,6 @@ local function findConnectedNodes()
 		end
 	end
 
-	local refClusterID = obj:getNodeCluster(refNode)
 	for cid,_ in pairs(v.data.nodes) do
 		if not connected[cid] then
 			if obj:getNodeCluster(cid) == refClusterID then
@@ -112,8 +133,12 @@ local function findConnectedNodes()
 	end
 	cog:setScaled(1/totalMass)
 	
-	local rot = quatFromDir(-obj:getDirectionVector(), obj:getDirectionVectorUp())
-	M.cogRel = cog:rotated(rot:inversed())
+	dir:set(obj:getDirectionVectorXYZ())
+	dir:setScaled(-1)
+	dirUp:set(obj:getDirectionVectorUpXYZ())
+	rot:setFromDir(dir, dirUp)
+	rot:inverse()
+	M.cogRel = cog:rotated(rot)
 end
 
 local function onInit()
@@ -197,7 +222,8 @@ local function addForce(nodes, x, y, z, isCounterVel)
 		local node = nodes[i]
 		if node then
 			if not isCounterVel or obj:getNodeCluster(node[1]) == mainClusterID then
-				obj:applyForceVector(node[1], float3(x*node[2], y*node[2], z*node[2]))
+				forceVec:set(x*node[2], y*node[2], z*node[2])
+				obj:applyForceVector(node[1], forceVec)
 			elseif isCounterVel then
 				table.remove(disconnectedNodes,i)
 			end
@@ -213,16 +239,17 @@ local function addVelocity(x, y, z)
 	if connectedNodeCount < disconnectedNodeCount then
 		addForce(nodes, x, y, z)
 	else
-		obj:applyClusterLinearAngularAccel(refNode,vec3(x, y, z)*physicsFPS, vec3())
+		forceVec:set(x*physicsFPS, y*physicsFPS, z*physicsFPS)
+		obj:applyClusterLinearAngularAccel(refNode,forceVec, zeroVec)
 		addForce(disconnectedNodes, -x, -y, -z, true)
 	end
 end
 
 -- Instantly set vehicle velocity in m/s
 local function setVelocity(x, y, z)
-	local vvel = obj:getVelocity()
+	local vvelX, vvelY, vvelZ = obj:getVelocityXYZ()
 	
-	addVelocity(x - vvel.x, y - vvel.y, z - vvel.z)
+	addVelocity(x - vvelX, y - vvelY, z - vvelZ)
 end
 
 -- Add angular velocity to vehicle in rad/s
@@ -230,8 +257,11 @@ end
 --               and apply enough force to reach the calculated speed in 1 physics tick.
 -- NOTE: - very high values can destroy vehicles (above about 20-30 rad/s for most cars) or cause instability
 local function addAngularForce(nodes, x, y, z, pitchAV, rollAV, yawAV, isCounterVel)
-	local rot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
-	local cog = M.cogRel:rotated(rot)
+	dir:set(obj:getDirectionVectorXYZ())
+	dir:setScaled(-1)
+	dirUp:set(obj:getDirectionVectorUpXYZ())
+	rot:setFromDir(dir, dirUp)
+	cog:set(M.cogRel:rotated(rot))
 	local mainClusterID = obj:getNodeCluster(refNode)
 	--print("addAngularVelocity: pitchAV: "..pitchAV..", rollAV: "..rollAV..", yawAV: "..yawAV)
 	for i=1, #nodes do
@@ -250,8 +280,10 @@ local function addAngularForce(nodes, x, y, z, pitchAV, rollAV, yawAV, isCounter
 				local forceX = (x + posY * yawAV - posZ * rollAV)*mul
 				local forceY = (y + posZ * pitchAV - posX * yawAV)*mul
 				local forceZ = (z + posX * rollAV - posY * pitchAV)*mul
+
+				forceVec:set(forceX, forceY, forceZ)
 				
-				obj:applyForceVector(cid, float3(forceX, forceY, forceZ))
+				obj:applyForceVector(cid, forceVec)
 			elseif isCounterVel then
 				table.remove(disconnectedNodes,i)
 			end
@@ -260,9 +292,16 @@ local function addAngularForce(nodes, x, y, z, pitchAV, rollAV, yawAV, isCounter
 end
 
 local function addAngularVelocity(x, y, z, pitchAV, rollAV, yawAV, onlyAngularVelocity, noCounterVelocity)
-	local rot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
-	local cog = M.cogRel:rotated(rot)
-	local vel = vec3(x, y, z) - cog:cross(vec3(pitchAV, rollAV, yawAV))
+	dir:set(obj:getDirectionVectorXYZ())
+	dir:setScaled(-1)
+	dirUp:set(obj:getDirectionVectorUpXYZ())
+	rot:setFromDir(dir, dirUp)
+	cog:set(M.cogRel:rotated(rot))
+	
+	rvel:set(pitchAV, rollAV, yawAV)
+	vel:set(x, y, z)
+	cog:setCross(cog, rvel)
+	vel:setSub(cog)
 	local velMulti = 1
 
 	if onlyAngularVelocity then
@@ -285,7 +324,9 @@ local function addAngularVelocity(x, y, z, pitchAV, rollAV, yawAV, onlyAngularVe
 			end
 		end
 	else
-		obj:applyClusterLinearAngularAccel(refNode,vel*physicsFPS*velMulti, -vec3(pitchAV, rollAV, yawAV)*physicsFPS)
+		rvel:setScaled(-physicsFPS)
+		vel:setScaled(physicsFPS*velMulti)
+		obj:applyClusterLinearAngularAccel(refNode, vel, rvel)
 		if noCounterVelocity then return end -- used on spawn and reset to wait with the counter velocity for a bit so things like logs on the T-series don't slide off
 		addAngularForce(disconnectedNodes, -x, -y, -z, -pitchAV, -rollAV, -yawAV, true)
 	end
@@ -293,18 +334,27 @@ end
 
 -- Instantly set vehicle angular velocity in rad/s
 local function setAngularVelocity(x, y, z, pitchAV, rollAV, yawAV, onlyAngularVelocity, noCounterVelocity)
-	local rot = quatFromDir(-vec3(obj:getDirectionVector()), vec3(obj:getDirectionVectorUp()))
-	local cog = M.cogRel:rotated(rot)
+	dir:set(obj:getDirectionVectorXYZ())
+	dir:setScaled(-1)
+	dirUp:set(obj:getDirectionVectorUpXYZ())
+	rot:setFromDir(dir, dirUp)
+	cog:set(M.cogRel:rotated(rot))
 	
-	local rvel = vec3(pitchAV, rollAV, yawAV)
-	local vrvel = vec3(obj:getPitchAngularVelocity(), obj:getRollAngularVelocity(), obj:getYawAngularVelocity()):rotated(rot)
-	local rvelDiff = rvel - vrvel
+	rvel:set(pitchAV, rollAV, yawAV)
+	vehRvel.y, vehRvel.x, vehRvel.z = obj:getRollPitchYawAngularVelocity()
+	local rvdX = rvel.x - vehRvel.x
+	local rvdY = rvel.y - vehRvel.y
+	local rvdZ = rvel.z - vehRvel.z
 	
-	local vel = vec3(x, y, z)
-	local vvel = vec3(obj:getVelocity()) + cog:cross(vrvel)
-	local velDiff = vel - vvel
+	vel:set(x, y, z)
+	vehVel:set(obj:getVelocityXYZ())
+	cog:setCross(cog, vehRvel)
+	vehVel:setAdd(cog)
+	local vdX = vel.x - vehVel.x
+	local vdY = vel.y - vehVel.y
+	local vdZ = vel.z - vehVel.z
 	
-	addAngularVelocity(velDiff.x, velDiff.y, velDiff.z, rvelDiff.x, rvelDiff.y, rvelDiff.z, onlyAngularVelocity, noCounterVelocity)
+	addAngularVelocity(vdX, vdY, vdZ, rvdX, rvdY, rvdZ, onlyAngularVelocity, noCounterVelocity)
 end
 
 local function updateGFX(dt)


### PR DESCRIPTION
Reduces the garbage generated by positionVE by about 75% from an average of ~4000 bytes to less than 1000 bytes per run of updateGFX.
Performance timings of the functions themselves are mostly the same, maybe a marginal improvement. It should help reduce stutters caused by garbage collection though.

Changes made:
- Updated most vector maths to use garbage free set...() functions or StackVec3
- Use cached variables for vec3s instead of creating new ones where possible
- Switched to XYZ variants of vehicle functions to avoid creating new vec3s there
- Updated sending code to reuse the table instead of recreating it and use a StringBuffer to assemble the string for queueing to GE

Initial testing watching people drive around in public servers seems fine.