### PR TITLE
Implement direct VE sockets

### DIFF
--- a/lua/ge/extensions/MPCoreNetwork.lua
+++ b/lua/ge/extensions/MPCoreNetwork.lua
@@ -571,6 +571,20 @@ local function handleU(params)
 	end
 end
 
+-- Handles launcher responses to direct VE socket requests
+local function handleDirectVE(params)
+	local code, serverVehicleID, data = string.match(params, "^(%a)%:(%d+%-%d+)%:(.*)")
+	local gameVehicleID = MPVehicleGE.getGameVehicleID(serverVehicleID) or -1 -- get gameID
+	local veh = getObjectByID(gameVehicleID)
+	if veh then
+		if code == "a" then
+			veh:queueLuaCommand("MPNetworkVE.setSocketConnected(true)")
+		elseif code == "d" then
+			veh:queueLuaCommand("MPNetworkVE.setSocketConnected(false)")
+		end
+	end
+end
+
 --- Prompts the user for auto join confirmation.
 -- @param params string The parameters received for auto join confirmation.
 -- @usage MPCoreNetwork.promptAutoJoin(`...`)
@@ -601,6 +615,7 @@ local HandleNetwork = {
 	['N'] = function(params) loginReceived(params) end,
 	['P'] = function(params) setProxyPort(params) end,
 	['U'] = function(params) handleU(params) end, -- Loading into server UI, handles loading mods, pre-join kick messages and ping
+	['V'] = function(params) handleDirectVE(params) end, -- Messages related to direct VE sockets
 	['W'] = function(params) handleModWarning(params) end,
 	['Z'] = function(params) launcherVersion = params; end,
 }
@@ -742,6 +757,17 @@ runPostJoin = function() -- gets called once loaded into a map
 	end
 end
 
+-- Notify launcher of direct VE ports, port being nil means the socket is deleted
+local function setDirectVEPort(serverVehicleID, port)
+	if not serverVehicleID then return end
+
+	if port then
+		send("Va:"..serverVehicleID..":"..tostring(port))
+	else
+		send("Vd:"..serverVehicleID)
+	end
+end
+
 --- This event is called as part of the games level loading process. It also works as the start event which can be paired with the end event onClientEndMission
 --- @usage `extensions.hook('onClientStartMission')`
 local function onClientStartMission()
@@ -801,6 +827,7 @@ M.disconnectLauncher   = disconnectLauncher
 M.isLauncherConnected  = isLauncherConnected
 M.getLauncherVersion   = getLauncherVersion
 M.getProxyPort         = getProxyPort
+M.setDirectVEPort      = setDirectVEPort
 -- security
 M.rejectModDownload    = rejectModDownload
 M.approveModDownload   = approveModDownload

--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1668,6 +1668,9 @@ local function onVehicleDestroyed(gameVehicleID)
 		if not vehicle then return end
 		local serverVehicleID = vehicle.serverVehicleString -- Get the serverVehicleID
 
+		-- Set direct VE port to nil to notify launcher of deleted vehicle
+		MPCoreNetwork.setDirectVEPort(serverVehicleID, nil)
+
 		vehicle.isSpawned = false
 		vehicle.isDeleted = true
 

--- a/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPElectricsVE.lua
@@ -391,7 +391,11 @@ local function check()
 		:: skip_electric ::
 	end
 	if electricsChanged then
-		obj:queueGameEngineLua("MPElectricsGE.sendElectrics(\'"..jsonEncode(electricsToSend).."\', "..obj:getID()..")")
+		if MPNetworkVE.socketConnected then
+			MPNetworkVE.send("We:", v.mpServerID, ":", jsonEncode(electricsToSend))
+		else
+			obj:queueGameEngineLua("MPElectricsGE.sendElectrics(\'"..jsonEncode(electricsToSend).."\', "..obj:getID()..")")
+		end
 	end
 end
 

--- a/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPInputsVE.lua
@@ -132,7 +132,12 @@ local function getInputs()
 	lastInputs.g = electrics.values.gear
 
 	if tableIsEmpty(inputsToSend) then return end
-	obj:queueGameEngineLua("MPInputsGE.sendInputs(\'"..jsonEncode(inputsToSend).."\', "..obj:getID()..")") -- Send it to GE lua
+
+	if MPNetworkVE.socketConnected then
+		MPNetworkVE.send("Vi:", v.mpServerID, ":", jsonEncode(inputsToSend))
+	else
+		obj:queueGameEngineLua("MPInputsGE.sendInputs(\'"..jsonEncode(inputsToSend).."\', "..obj:getID()..")") -- Send it to GE lua
+	end
 end
 
 local function storeTargetValue(inputName,inputState)

--- a/lua/vehicle/extensions/BeamMP/MPNetworkVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPNetworkVE.lua
@@ -1,0 +1,175 @@
+-- Copyright (C) 2026 BeamMP Ltd., BeamMP team and contributors.
+-- Licensed under AGPL-3.0 (or later), see <https://www.gnu.org/licenses/>.
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+local M = {}
+
+local socket = require("socket")
+local udp = nil
+M.socketConnected = false
+
+local stringBuffer = require("string.buffer")
+local sendStringBuff = stringBuffer.new()
+
+local function send(...)
+	if udp then
+		sendStringBuff:reset()
+		sendStringBuff:put(...)
+
+		return udp:send(sendStringBuff:tostring())
+	end
+end
+
+local function handleInput(rawData)
+	local code, serverVehicleID, data = string.match(rawData, "^(%a)%:(%d+%-%d+)%:({.*})")
+	if v.mpServerID ~= serverVehicleID then return end
+
+	if code == 'i' then
+		MPInputsVE.applyInputs(data)
+	else
+		log('W', 'handle', "Received unknown input packet '"..tostring(code).."'! ".. rawData)
+	end
+end
+
+local function handleElectrics(rawData)
+	local code, serverVehicleID, data = string.match(rawData, "^(%a)%:(%d+%-%d+)%:({.*})")
+	if v.mpServerID ~= serverVehicleID then return end
+
+	if code == "e" then -- Electrics (indicators, lights etc...)
+		MPElectricsVE.applyElectrics(data, serverVehicleID)
+	else
+		log('W', 'handle', "Received unknown electrics packet '"..tostring(code).."'! ".. rawData)
+	end
+end
+
+local function handleNodes(rawData)
+	local code, serverVehicleID, data = string.match(rawData, "^(%a)%:(%d+%-%d+)%:(.*)")
+	if v.mpServerID ~= serverVehicleID then return end
+
+	if code == "n" then
+		nodesVE.applyNodes(data)
+	elseif code == "g" then
+		nodesVE.applyBreakGroups(data)
+	elseif code == "c" then
+		controllerSyncVE.applyControllerData(data)
+	else
+		log('W', 'handle', "Received unknown nodes packet '"..tostring(code).."'! ".. rawData)
+	end
+end
+
+local function handlePowertrain(rawData)
+	local code, serverVehicleID, data = string.match(rawData, "^(%a)%:(%d+%-%d+)%:({.*})")
+	if v.mpServerID ~= serverVehicleID then return end
+
+	if code == "l" then
+		MPPowertrainVE.applyLivePowertrain(data)
+	elseif code == "e" then
+		MPPowertrainVE.applyEngineData(data)
+	elseif code == "h" then
+		MPPowertrainHydrosVE.applyHydroBeams(data)
+	else
+		log('W', 'handle', "Received unknown powertrain packet '"..tostring(code).."'! ".. rawData)
+	end
+end
+
+local function handlePosition(rawData)
+	local code, serverVehicleID, data = string.match(rawData, "^(%a)%:(%d+%-%d+)%:({.*})")
+	if v.mpServerID ~= serverVehicleID then return end
+
+	if code == 'p' then
+		positionVE.applyPositionData(data)
+	else
+		log('W', 'handle', "Received unknown position packet '"..tostring(code).."'! ".. rawData)
+	end
+end
+
+local HandleNetwork = {
+	['V'] = function(params) handleInput(params) end, -- inputs and gears
+	['W'] = function(params) handleElectrics(params) end,
+	['X'] = function(params) handleNodes(params) end, -- currently disabled
+	['Y'] = function(params) handlePowertrain(params) end, -- powertrain related things like diff locks and transfercases
+	['Z'] = function(params) handlePosition(params) end, -- position and velocity
+	--['R'] = function(params) MPControllerGE.handle(params) end, -- Controller data
+}
+
+local function updateGFX(dt)
+	if udp and v.mpServerID then
+		while true do
+			local received, err = udp:receive()
+			if received then
+				-- break it up into code + data
+				local code = string.sub(received, 1, 1)
+				local data = string.sub(received, 2)
+				if HandleNetwork[code] then
+					HandleNetwork[code](data)
+				else
+					log('D', "updateGFX", "Vehicle " .. tostring(v.mpServerID) .. " received data: " .. tostring(data))
+				end
+			else
+				break
+			end
+		end
+	end
+end
+
+local function closeDirectVESocket()
+	log('D', "closeDirectVESocket", "Closing direct VE UDP socket for vehicle " .. tostring(v.mpServerID))
+
+	if udp then
+		udp:close()
+		udp = nil
+
+		obj:queueGameEngineLua("MPCoreNetwork.setDirectVEPort('" .. tostring(v.mpServerID) .. "')")
+	end
+
+	M.socketConnected = false
+end
+
+local function createDirectVESocket()
+	if not v.mpServerID then
+		log('E', "createDirectVESocket", "Can not direct VE UDP socket: missing mpServerID")
+		M.socketConnected = false
+	end
+
+	if udp then
+		log('D', "createDirectVESocket", "Direct VE UDP socket for vehicle " .. tostring(v.mpServerID) .. " already exists, updating server ID.")
+
+		local _, port = udp:getsockname()
+		obj:queueGameEngineLua("MPCoreNetwork.setDirectVEPort('" .. tostring(v.mpServerID) .. "', " .. tostring(port) .. ")")
+		return
+	end
+
+	log('D', "createDirectVESocket", "Setting up direct VE UDP socket for vehicle " .. tostring(v.mpServerID))
+
+	udp = socket.udp()
+	udp:settimeout(0)
+	local success, err = udp:setsockname("127.0.0.1", 0)
+	if success then
+		udp:setpeername((settings.getValue("launcherIp") or "127.0.0.1"), (settings.getValue("launcherPort") or 4444)+2)
+		local _, port = udp:getsockname()
+		log('I', "createDirectVESocket", "Direct VE UDP socket for vehicle " .. tostring(v.mpServerID) .. " listening on port " .. tostring(port))
+		obj:queueGameEngineLua("MPCoreNetwork.setDirectVEPort('" .. tostring(v.mpServerID) .. "', " .. tostring(port) .. ")")
+	else
+		log('E', "createDirectVESocket", "Failed to set up direct VE UDP socket for vehicle " .. tostring(v.mpServerID) .. ": " .. tostring(err))
+	end
+end
+
+local function setSocketConnected(connected)
+	M.socketConnected = connected
+end
+
+local function onExtensionLoaded()
+	if v.mpServerID then
+		createDirectVESocket()
+	end
+end
+
+M.send = send
+M.updateGFX = updateGFX
+M.createDirectVESocket = createDirectVESocket
+M.closeDirectVESocket = closeDirectVESocket
+M.setSocketConnected = setSocketConnected
+M.onExtensionLoaded = onExtensionLoaded
+M.onExtensionUnloaded = closeDirectVESocket
+
+return M

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainHydrosVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainHydrosVE.lua
@@ -36,7 +36,11 @@ local function getHydroBeams()
         end
     end
     if foundChangedBeams then
-	    obj:queueGameEngineLua("MPPowertrainGE.sendHydroBeamData(\'"..jsonEncode(hydroBeamsToSend).."\', "..obj:getID()..")")
+        if MPNetworkVE.socketConnected then
+            MPNetworkVE.send("Yh:", v.mpServerID, ":", jsonEncode(hydroBeamsToSend))
+        else
+            obj:queueGameEngineLua("MPPowertrainGE.sendHydroBeamData(\'"..jsonEncode(hydroBeamsToSend).."\', "..obj:getID()..")")
+        end
     end
 
     for _, electricsName in pairs(hydroBeamsElectricsNames) do

--- a/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPPowertrainVE.lua
@@ -47,7 +47,11 @@ local function getPowerTrainData()
 		end
 	end
 	if next(devicesToSend) then
-		obj:queueGameEngineLua("MPPowertrainGE.sendLivePowertrain(\'"..jsonEncode(devicesToSend).."\', "..obj:getID()..")")
+		if MPNetworkVE.socketConnected then
+			MPNetworkVE.send("Yl:", v.mpServerID, ":", jsonEncode(devicesToSend))
+		else
+			obj:queueGameEngineLua("MPPowertrainGE.sendLivePowertrain(\'"..jsonEncode(devicesToSend).."\', "..obj:getID()..")")
+		end
 		-- print("Devices "..jsonEncode(devicesToSend).." sent")
 	end
 end
@@ -95,7 +99,11 @@ local function getEngineData() --TODO maybe hook the functions instead of checki
 	data = getCombustionEngineData(data)
 
 	if next(data) then
-		obj:queueGameEngineLua("MPPowertrainGE.sendEngineData(\'"..jsonEncode(data).."\', "..obj:getID()..")")
+		if MPNetworkVE.socketConnected then
+			MPNetworkVE.send("Ye:", v.mpServerID, ":", jsonEncode(data))
+		else
+			obj:queueGameEngineLua("MPPowertrainGE.sendEngineData(\'"..jsonEncode(data).."\', "..obj:getID()..")")
+		end
 	end
 end
 

--- a/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
+++ b/lua/vehicle/extensions/BeamMP/MPVehicleVE.lua
@@ -5,7 +5,7 @@
 local M = {}
 
 v.mpVehicleType = "L" -- we assume vehicles are local (they're set to remove once we receive pos data from the server)
-v.mpServerID = ""
+v.mpServerID = nil
 
 local keyStates = {} -- table of keys and their states, used as a reference
 local keysToPoll = {} -- list of keys we want to poll for state changes
@@ -60,6 +60,8 @@ end
 
 local function setServerID(id)
   v.mpServerID = id
+
+  MPNetworkVE.createDirectVESocket()
 end
 
 local function updateGFX(dtReal)

--- a/lua/vehicle/extensions/BeamMP/controllerSyncVE.lua
+++ b/lua/vehicle/extensions/BeamMP/controllerSyncVE.lua
@@ -20,8 +20,12 @@ local framesSinceReset = 0
 local hookExstensions
 
 local function sendControllerData(tempTable) -- using nodesGE temporarely until launcher and server supports the new packet
-	--obj:queueGameEngineLua("MPControllerGE.sendControllerData(\'" .. jsonEncode(tempTable) .. "\', " .. obj:getID() ..")") -- Send it to GE lua
-	obj:queueGameEngineLua("nodesGE.sendControllerData(\'" .. jsonEncode(tempTable) .. "\', " .. obj:getID() ..")") -- Send it to GE lua
+	if MPNetworkVE.socketConnected then
+		MPNetworkVE.send("Xc:", v.mpServerID, ":", jsonEncode(tempTable))
+	else
+		--obj:queueGameEngineLua("MPControllerGE.sendControllerData(\'" .. jsonEncode(tempTable) .. "\', " .. obj:getID() ..")") -- Send it to GE lua
+		obj:queueGameEngineLua("nodesGE.sendControllerData(\'" .. jsonEncode(tempTable) .. "\', " .. obj:getID() ..")") -- Send it to GE lua
+	end
 end
 
 local function mergeTable(tempTable , table)

--- a/lua/vehicle/extensions/BeamMP/couplerVE.lua
+++ b/lua/vehicle/extensions/BeamMP/couplerVE.lua
@@ -90,7 +90,13 @@ local function onCouplerAttached(nodeId, obj2id, obj2nodeId, attachSpeed, attach
 			table.insert(MPcouplerdata,MPcouplers)
 		end
 
-		obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'"..jsonEncode(MPcouplerdata).."\'," ..tostring(obj:getID())..")")
+		-- NOTE: 'O' packets are also used for vehicle spawns and other things, we can still send them over the direct VE socket, 
+		-- but receiving has to be done through GE Lua
+		if MPNetworkVE.socketConnected then
+            MPNetworkVE.send("Ot:", v.mpServerID, ":", jsonEncode(MPcouplerdata))
+        else
+            obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'"..jsonEncode(MPcouplerdata).."\'," ..tostring(obj:getID())..")")
+        end
 	end
 
 	lastNodeIDcoupled = nodeId
@@ -132,7 +138,13 @@ local function onCouplerDetached(nodeId, obj2id, obj2nodeId)
 			table.insert(MPcouplerdata,MPcouplers)
 		end
 
-		obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'"..jsonEncode(MPcouplerdata).."\'," ..tostring(obj:getID())..")")
+		-- NOTE: 'O' packets are also used for vehicle spawns and other things, we can still send them over the direct VE socket, 
+		-- but receiving has to be done through GE Lua
+		if MPNetworkVE.socketConnected then
+            MPNetworkVE.send("Ot:", v.mpServerID, ":", jsonEncode(MPcouplerdata))
+        else
+            obj:queueGameEngineLua("MPVehicleGE.sendBeamstate(\'"..jsonEncode(MPcouplerdata).."\'," ..tostring(obj:getID())..")")
+        end
 	end
 
 	lastNodeIDdecoupled = nodeId

--- a/lua/vehicle/extensions/BeamMP/nodesVE.lua
+++ b/lua/vehicle/extensions/BeamMP/nodesVE.lua
@@ -95,7 +95,11 @@ local function getNodes()
     save.beams[beam.cid + 1] = d
   end]]
 
-	obj:queueGameEngineLua("nodesGE.sendNodes(\'"..jsonEncode(save).."\', "..obj:getID()..")") -- Send it to GE lua
+  if MPNetworkVE.socketConnected then
+		MPNetworkVE.send("Xn:", v.mpServerID, ":", jsonEncode(save))
+	else
+		obj:queueGameEngineLua("nodesGE.sendNodes(\'"..jsonEncode(save).."\', "..obj:getID()..")") -- Send it to GE lua
+	end
 end
 
 
@@ -218,7 +222,11 @@ local function getBreakGroups()
 		return
 	end
 
-	obj:queueGameEngineLua("nodesGE.sendBreakGroups(\'"..jsonEncode(breakGroupArray).."\', "..obj:getID()..")") -- Send it to GE lua
+  if MPNetworkVE.socketConnected then
+		MPNetworkVE.send("Xg:", v.mpServerID, ":", jsonEncode(breakGroupArray))
+	else
+	  obj:queueGameEngineLua("nodesGE.sendBreakGroups(\'"..jsonEncode(breakGroupArray).."\', "..obj:getID()..")") -- Send it to GE lua
+	end
 end
 
 local function onBreakGroupBroken(g)

--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -193,36 +193,42 @@ end
 
 
 
+local function applyPositionData(jsonData)
+	local pr = jsonDecode(jsonData)
+	local pos  = vec3(pr.pos)
+	local vel  = vec3(pr.vel)
+	local rot  = quat(pr.rot)
+	local rvel = vec3(pr.rvel)
+	local tim  = pr.tim
+	local ping = pr.ping
+	local simspeedfraction = 1/simSpeedReal
+
+	if not tim then return end
+	if remoteData.timer > tim then return end
+
+	local remoteDT = max(tim - remoteData.timer, 0.001)
+
+	remoteData.pos = pos
+	remoteData.rot = rot
+	remoteData.acc = limitVecLength((vel - remoteData.vel)/remoteDT, maxAcc)
+	remoteData.racc = limitVecLength((rvel - remoteData.rvel)/remoteDT, maxRacc)
+	remoteData.vel = vel*simspeedfraction
+	remoteData.rvel = rvel*simspeedfraction
+	remoteData.timer = tim
+	remoteData.timeOffset = timer-tim - ownPing/2 - ping/2 - lastDT
+	remoteData.recTime = timer
+	remoteData.localSimspeed = math.min(simspeedfraction, 25)
+end
+
+
+
 local function updateRemoteData()
-	if not v.mpServerID or v.mpServerID == "" then return end
+	if not v.mpServerID then return end
 	local mailBoxName = "vehPosPckt" .. v.mpServerID
 	local currentMailBoxVersion = obj:getLastMailboxVersion(mailBoxName)
 	if lastMailboxVersion ~= currentMailBoxVersion then
 		local jsonData = obj:getLastMailbox(mailBoxName)
-		local pr = jsonDecode(jsonData)
-		local pos  = vec3(pr.pos)
-		local vel  = vec3(pr.vel)
-		local rot  = quat(pr.rot)
-		local rvel = vec3(pr.rvel)
-		local tim  = pr.tim
-		local ping = pr.ping
-		local simspeedfraction = 1/simSpeedReal
-
-		if not tim then return end
-		if remoteData.timer > tim then return end
-
-		local remoteDT = max(tim - remoteData.timer, 0.001)
-
-		remoteData.pos = pos
-		remoteData.rot = rot
-		remoteData.acc = limitVecLength((vel - remoteData.vel)/remoteDT, maxAcc)
-		remoteData.racc = limitVecLength((rvel - remoteData.rvel)/remoteDT, maxRacc)
-		remoteData.vel = vel*simspeedfraction
-		remoteData.rvel = rvel*simspeedfraction
-		remoteData.timer = tim
-		remoteData.timeOffset = timer-tim - ownPing/2 - ping/2 - lastDT
-		remoteData.recTime = timer
-		remoteData.localSimspeed = math.min(simspeedfraction, 25)
+		applyPositionData(jsonData)
 	end
 	lastMailboxVersion = currentMailBoxVersion
 end
@@ -412,7 +418,12 @@ local function getVehicleRotation()
 		tim = timer,
 		ping = ownPing + lastDT
 	}
-	obj:queueGameEngineLua("positionGE.sendVehiclePosRot(\'"..jsonEncode(tempTable).."\', "..obj:getID()..")") -- Send it
+
+	if MPNetworkVE.socketConnected then
+		MPNetworkVE.send("Zp:", v.mpServerID, ":", jsonEncode(tempTable))
+	else
+		obj:queueGameEngineLua("positionGE.sendVehiclePosRot(\'"..jsonEncode(tempTable).."\', "..obj:getID()..")") -- Send it
+	end
 end
 
 
@@ -431,6 +442,7 @@ M.onExtensionLoaded  = onInit
 M.onPhysicsStep      = update
 M.updateGFX          = updateGFX
 M.getVehicleRotation = getVehicleRotation
+M.applyPositionData  = applyPositionData
 M.setPing            = setPing
 M.setGameSpeed       = setGameSpeed
 


### PR DESCRIPTION
Allows individual VE Lua instances to connect directly to the launcher through a UDP socket. This skips having to queue data to GE Lua first, improving latency and reducing processing overhead.

Requires BeamMP/BeamMP-Launcher#245 on the launcher side, but is fully compatible with the current launcher (falls back to old system).

How it works:
1. When VE Lua gets notified of the vehicles server ID, a UDP socket is opened.
2. The port of the opened socket is sent to the launcher in a connection request on CoreNetwork.
3. If the launcher handled the request successfully, it will send back a response.
4. If a response is received, VE Lua is notified and the socket is considered connected.
5. After that, all vehicle data sent and received on GameNetwork will be routed directly through the vehicle socket, bypassing GE Lua.

If any part in the chain fails, it will fall back to the current system of going through GE Lua.

Thanks to @Olrosse for helping with the Lua implementation.