### PR TITLE
telport fix

### DIFF
--- a/lua/vehicle/extensions/BeamMP/positionVE.lua
+++ b/lua/vehicle/extensions/BeamMP/positionVE.lua
@@ -272,7 +272,7 @@ local function updateGFX(dt)
 
 
 	-- If there is no received data, or data is older than timeout, do nothing
-	if remoteData.timer < 0 or (timer-remoteData.recTime) > packetTimeout then return end
+	if v.mpVehicleType == "L" or remoteData.timer < 0 or (timer-remoteData.recTime) > packetTimeout then return end
 
 	-- Local vehicle data
 	dir:set(obj:getDirectionVectorXYZ())


### PR DESCRIPTION
fixed bug where sometimes your car would teleport to a specific spot on every reset,
this was happening if your car server id was used in a mailbox previously, this is likely to happen when joining a second server without having restarted the game