### PR TITLE
vehicle spawn improvements

### DIFF
--- a/lua/ge/extensions/MPVehicleGE.lua
+++ b/lua/ge/extensions/MPVehicleGE.lua
@@ -1448,7 +1448,7 @@ local function applyVehSpawn(event)
 		spawnedVeh:setField("absMode", 0, absMode or "")
 	else
 		log('W', 'applyVehSpawn', "Spawning new vehicle "..vehicleName.." from server")
-		spawnedVeh = spawn.spawnVehicle(vehicleName, serialize(vehicleConfig), pos, rot, { autoEnterVehicle=false, vehicleName="multiplayerVehicle", cling=true})
+		spawnedVeh = spawn.spawnVehicle(vehicleName, serialize(vehicleConfig), pos, rot, { autoEnterVehicle=false, vehicleName="multiplayerVehicle", cling=true, centeredPosition = true, removeWhenNoPositionFound = false})
 		spawnedVehID = spawnedVeh:getID()
 		spawnedVeh:setField("protected", 0, protected or "0")
 		spawnedVeh:setField("absMode", 0, absMode or "")


### PR DESCRIPTION
vehicle's now use the center position on spawn, this is much closer to the COG we use for position packets
added flag to not cancel the spawn if the game doesn't find a suitable spawn position