### PR TITLE
Instabiliy handling improvements

### DIFF
--- a/locales/translations/cs/beammp/options.translation.json
+++ b/locales/translations/cs/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/de_DE/beammp/options.translation.json
+++ b/locales/translations/de_DE/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/en-US/beammp/options.translation.json
+++ b/locales/translations/en-US/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/es_ES/beammp/options.translation.json
+++ b/locales/translations/es_ES/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/fr_FR/beammp/options.translation.json
+++ b/locales/translations/fr_FR/beammp/options.translation.json
@@ -43,8 +43,6 @@
   "ui.options.beammp.showPlayerIDs.tooltip": "Activer cette option pour afficher les identifiants des joueurs dans la liste des joueurs.",
   "ui.options.beammp.disableLuaReload": "Désactiver le rechargement de Lua lors de la déconnexion d'un serveur multijoueur.",
   "ui.options.beammp.disableLuaReload.tooltip": "Le rechargement du script Lua est nécessaire pour que le jeu retrouve son état de fonctionnement normal si des mods ont modifié certaines fonctions. Vous pouvez le désactiver pour une expérience plus fluide, mais à vos risques et périls.",
-  "ui.options.beammp.disableInstabilityPausing": "Désactiver les pauses dues aux instabilités",
-  "ui.options.beammp.disableInstabilityPausing.tooltip": "Cela rendra le jeu plus fluide, mais peut entraîner des problèmes de synchronisation après plusieurs instabilités.",
   "ui.options.beammp.simplifyRemoteVehicles": "Utilisez des véhicules simplifiés lorsqu'ils sont disponibles",
   "ui.options.beammp.simplifyRemoteVehicles.tooltip": "Ce paramètre remplace les véhicules distants par les versions « trafic » fournies par BeamNG. Cela réduit la précision des collisions et des effets visuels, mais améliore les performances.",
   "ui.options.beammp.enableBlobs": "Activer les blobs pour les véhicules non générés",

--- a/locales/translations/hu/beammp/options.translation.json
+++ b/locales/translations/hu/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/ja_JP/beammp/options.translation.json
+++ b/locales/translations/ja_JP/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/pl-PL/beammp/options.translation.json
+++ b/locales/translations/pl-PL/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/pl_PL/beammp/options.translation.json
+++ b/locales/translations/pl_PL/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/pt_BR/beammp/options.translation.json
+++ b/locales/translations/pt_BR/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/pt_PT/beammp/options.translation.json
+++ b/locales/translations/pt_PT/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/ru_RU/beammp/options.translation.json
+++ b/locales/translations/ru_RU/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/sv-SE/beammp/options.translation.json
+++ b/locales/translations/sv-SE/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/tr_TR/beammp/options.translation.json
+++ b/locales/translations/tr_TR/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/uk/beammp/options.translation.json
+++ b/locales/translations/uk/beammp/options.translation.json
@@ -43,8 +43,6 @@
     "ui.options.beammp.showPlayerIDs.tooltip": "Enable to show player ID's in the player list.",
     "ui.options.beammp.disableLuaReload": "Disable Lua reloading when quitting a multiplayer server.",
     "ui.options.beammp.disableLuaReload.tooltip": "Lua reloads are required to ensure that the game is put back to a working state if mods had replaced game functions. Can be disabled for a smoother experience at your own risk.",
-    "ui.options.beammp.disableInstabilityPausing": "Disable pausing caused by instabilities",
-    "ui.options.beammp.disableInstabilityPausing.tooltip": "This will make gameplay smoother but can cause sync issues after several instabilities",
     "ui.options.beammp.simplifyRemoteVehicles": "Use simplified vehicles when available",
     "ui.options.beammp.simplifyRemoteVehicles.tooltip": "This setting will replace remote vehicles with the BeamNG provided 'traffic' versions. Reduces accuracy of collisions and visuals, but improves performance",
     "ui.options.beammp.enableBlobs": "Enable blobs for unspawned vehicles",

--- a/locales/translations/zh_Hans/beammp/options.translation.json
+++ b/locales/translations/zh_Hans/beammp/options.translation.json
@@ -43,8 +43,6 @@
   "ui.options.beammp.showPlayerIDs.tooltip": "启用后，在玩家列表中显示玩家 ID。",
   "ui.options.beammp.disableLuaReload": "禁用退出多人服务器时的 Lua 重新加载",
   "ui.options.beammp.disableLuaReload.tooltip": "如果模组替换了游戏功能，重新加载 Lua 可确保游戏恢复正常运行。您可以禁用此功能以获得更流畅的体验，但需自行承担风险。",
-  "ui.options.beammp.disableInstabilityPausing": "禁用因连接不稳定导致的暂停",
-  "ui.options.beammp.disableInstabilityPausing.tooltip": "这将使游戏体验更加流畅，但在多次出现连接不稳定后可能会导致同步问题",
   "ui.options.beammp.simplifyRemoteVehicles": "可用时使用简化车辆",
   "ui.options.beammp.simplifyRemoteVehicles.tooltip": "此设置将使用 BeamNG 提供的“交通车辆”版本替换其他玩家的车辆。这样会降低碰撞效果和视觉表现的准确性，但可以提升性能。",
   "ui.options.beammp.enableBlobs": "为未生成的车辆启用 Blobs",

--- a/lua/ge/extensions/MPConfig.lua
+++ b/lua/ge/extensions/MPConfig.lua
@@ -81,8 +81,6 @@ local defaultSettings = {
 	unicycleConfigs = getUnicycleConfigs(), unicycleAutoSave = true,
 	--unicycle_pc = nil, -- temp value introduced to share the user selected default unicycle config from the multiplayer.partial ui to MPConfig.setDefaultUnicycle()
 
-	disableInstabilityPausing = true,
-
 	refreshIngame = false,
 
 	playerlistLeftclick = 0, -- 0 - queue events, 1 - switch camera, 2 - open forum, 3 - delete, 4 - restore, 5 - copy name

--- a/lua/ge/extensions/beammp/multiplayer.lua
+++ b/lua/ge/extensions/beammp/multiplayer.lua
@@ -69,6 +69,7 @@ end
 --- A custom onInstabilityDetected function to prevent the vehicles from being deleted instantly when in MP session
 --- @param jbeamFilename table Object jbeam data of the object causing the instability
 local vehicleInstabilityState = {}
+local canDeleteVehicles = true
 local vehInstability = false
 local instabilityTimer = 0
 local instabilityFrameCount = 0
@@ -125,7 +126,7 @@ local function instabilityHandlerUpdate(dt)
 					if states.triggered then
 						local veh = getObjectByID(vehID)
 						if veh then
-							if states.instabilityCount > 10 then
+							if canDeleteVehicles and states.instabilityCount > 10 then
 								ui_message(""..veh:getJBeamFilename().." had too many instabilities and was deleted\n\nRight click the player's name and queue deleted vehicles to respawn it", 20, 'instabilityDelete'..veh:getJBeamFilename()..''.. vehID, "warning")
 								veh:delete()
 								vehicleInstabilityState[vehID] = nil --TODO put in spawn queue instead of clearing it
@@ -169,6 +170,13 @@ local function instabilityHandlerUpdate(dt)
 	end
 end
 
+local function enableInstabilityDeletion()
+	canDeleteVehicles = true
+end
+
+local function disableInstabilityDeletion()
+	canDeleteVehicles = false
+end
 
 --- onUpdate is a game eventloop function. It is called each frame by the game engine.
 --- This is the main processing thread of BeamMP in the game
@@ -260,6 +268,8 @@ M.onWorldReadyState = onWorldReadyState
 M.onBigMapActivated = onBigMapActivated
 M.onBeamMPServerLeave = onServerLeave
 M.onInstabilityDetected = onInstabilityDetected
+M.enableInstabilityDeletion = enableInstabilityDeletion
+M.disableInstabilityDeletion = disableInstabilityDeletion
 M.onInit = function() setExtensionUnloadMode(M, "manual") end
 
 return M

--- a/lua/ge/extensions/beammp/multiplayer.lua
+++ b/lua/ge/extensions/beammp/multiplayer.lua
@@ -15,7 +15,6 @@ local M = {state={}}
 local originalGetDriverData
 local originalToggleWalkingMode
 local originalOnVehicleSwitched
-local original_onInstabilityDetected
 
 
 --- Custom GetDriverData for allowing the getting of the right hand door or not for passenger aspects.
@@ -59,12 +58,6 @@ local function modifiedOnVehicleSwitched(oldId, newId, player)
 	end
 end
 
---- A custom onInstabilityDetected function to prevent the freezing / pausing of the game for when in MP session
---- @param jbeamFilename table Object jbeam data of the object causing the instability
-local function modified_onInstabilityDetected(jbeamFilename)
-	log('E', "", "Instability detected for vehicle " .. tostring(jbeamFilename))
-end
-
 
 --- Called when the Big Map is loaded by the user. 
 local function onBigMapActivated() -- don't pause the game when opening the Big Map
@@ -73,11 +66,115 @@ local function onBigMapActivated() -- don't pause the game when opening the Big 
 	end
 end
 
+--- A custom onInstabilityDetected function to prevent the vehicles from being deleted instantly when in MP session
+--- @param jbeamFilename table Object jbeam data of the object causing the instability
+local vehicleInstabilityState = {}
+local vehInstability = false
+local instabilityTimer = 0
+local instabilityFrameCount = 0
+local hasRecovered = true
+local function onInstabilityDetected(vid, returnData)
+	local v = getObjectByID(vid)
+	local jbeamFilename = v:getJBeamFilename()
+  	v:queueLuaCommand('obj:requestReset(RESET_PHYSICS)')
+	returnData.instabilityHandled = true -- tells BeamNG that we have handled the instability
+
+	if vehicleInstabilityState[vid] then -- if vehicle has had an instability already
+		local newTime = os:clock()
+		local timeDiff = math.abs(vehicleInstabilityState[vid].time - newTime)
+		if timeDiff > 4 then -- reset the instability counter if it's more than 4 seconds since last instability, to reduce vehicle deletions when doing crazy things 
+			vehicleInstabilityState[vid].instabilityCount = 0
+		elseif timeDiff < 1/30 then -- there often seem to be a duplicate instability, so if it's less than one 30th of a second since the last one we ignore it
+			return
+		end
+		vehicleInstabilityState[vid].time = newTime
+		vehicleInstabilityState[vid].instabilityCount = vehicleInstabilityState[vid].instabilityCount + 1
+	else
+		vehicleInstabilityState[vid] = {instabilityCount = 1, triggered = false, setActive = false, time = os:clock()}
+	end
+
+	if not vehicleInstabilityState[vid].setActive and vehicleInstabilityState[vid].instabilityCount > 3 then
+		v:setActive(0) -- deactivate vehicle to prevent more vehicles from getting hit by the unstable vehicle
+		if instabilityTimer == 0 then
+			instabilityTimer = 1
+			instabilityFrameCount = 0
+		elseif instabilityTimer < 0 then
+			instabilityFrameCount = 0
+			instabilityTimer = 0.5
+		end
+		vehicleInstabilityState[vid].triggered = true
+		vehInstability = true
+		ui_message("Multiple Instabilities detected in \'"..jbeamFilename.."\' "..vehicleInstabilityState[vid].instabilityCount.." vehicle deactivated temporarily", 10, 'instability'..jbeamFilename..'', "danger")
+	end
+
+	if vehicleInstabilityState[vid].setActive then
+		vehicleInstabilityState[vid].setActive = false
+	end
+end
+
+local function instabilityHandlerUpdate(dt)
+	if vehInstability then
+		if instabilityTimer < 0 then
+			instabilityFrameCount = instabilityFrameCount + 1
+			if instabilityFrameCount == 1 then
+				hasRecovered = false
+				ui_message("Attempting to reactivate unstable vehicles", 10, 'instabilityReactivate', "warning")
+			elseif instabilityFrameCount == 2 then
+				log("E", "", "reactivating vehicles")
+				for vehID, states in pairs(vehicleInstabilityState) do
+					if states.triggered then
+						local veh = getObjectByID(vehID)
+						if veh then
+							if states.instabilityCount > 10 then
+								ui_message(""..veh:getJBeamFilename().." had too many instabilities and was deleted\n\nRight click the player's name and queue deleted vehicles to respawn it", 10, 'instabilityDelete'..veh:getJBeamFilename()..''.. vehID, "warning")
+								veh:delete()
+								vehicleInstabilityState[vehID] = nil --TODO put in spawn queue instead of clearing it
+							else
+								veh:setActive(1)
+								vehicleInstabilityState[vehID].setActive = true
+							end
+						end
+					end
+				end
+			elseif instabilityFrameCount > 3 and not hasRecovered then
+				local isStable = true
+				for vehID, states in pairs(vehicleInstabilityState) do
+					local veh = getObjectByID(vehID)
+					if veh then
+						if not veh:getActive() then
+							veh:setActive(1)
+							vehicleInstabilityState[vehID].setActive = true
+  							veh:queueLuaCommand('obj:requestReset(RESET_PHYSICS)')
+						end
+						if isnaninf(veh:getVelocity():length()) then
+							isStable = false
+						else
+							if states.triggered then
+								vehicleInstabilityState[vehID].triggered = false
+							end
+						end
+					end
+				end
+
+				if isStable or instabilityTimer < -10 then
+					instabilityFrameCount = 0
+					vehInstability = false
+					instabilityTimer = 0
+					hasRecovered = true
+					return
+				end
+			end
+		end
+		instabilityTimer = instabilityTimer - dt
+	end
+end
+
 
 --- onUpdate is a game eventloop function. It is called each frame by the game engine.
 --- This is the main processing thread of BeamMP in the game
 --- @param dt float
 local function onUpdate(dt)
+	instabilityHandlerUpdate(dt)
 	if MPCoreNetwork and MPCoreNetwork.isMPSession() then
 		--log('W', 'onUpdate', 'Running modified beammp code!')
 		if core_camera.getDriverData ~= modifiedGetDriverData then
@@ -108,24 +205,8 @@ local function onUpdate(dt)
 end
 
 
-
-
---- This function/event is triggered internally upon the joining on a map.
-local function runPostJoin()
-	--save the original functions so they can be restored after leaving an mp session
-	original_onInstabilityDetected = onInstabilityDetected
-
-	--replace the functions
-	if settings.getValue("disableInstabilityPausing") then
-		onInstabilityDetected = modified_onInstabilityDetected
-	end
-	onInstabilityDetected = modified_onInstabilityDetected
-end
-
-
 --- This function is called when the user leaves a server as part of cleanup 
 local function onServerLeave()
-	if original_onInstabilityDetected then onInstabilityDetected = original_onInstabilityDetected end
 	if originalGetDriverData then core_camera.getDriverData = originalGetDriverData end
 	if originalToggleWalkingMode and gameplay_walk and gameplay_walk.toggleWalkingMode then gameplay_walk.toggleWalkingMode = originalToggleWalkingMode end
 	if originalOnVehicleSwitched and gameplay_walk and gameplay_walk.onVehicleSwitched then gameplay_walk.onVehicleSwitched = originalOnVehicleSwitched end
@@ -177,8 +258,8 @@ end
 M.onUpdate          = onUpdate
 M.onWorldReadyState = onWorldReadyState
 M.onBigMapActivated = onBigMapActivated
-M.onBeamMPPostJoin = runPostJoin
 M.onBeamMPServerLeave = onServerLeave
+M.onInstabilityDetected = onInstabilityDetected
 M.onInit = function() setExtensionUnloadMode(M, "manual") end
 
 return M

--- a/lua/ge/extensions/beammp/multiplayer.lua
+++ b/lua/ge/extensions/beammp/multiplayer.lua
@@ -126,7 +126,7 @@ local function instabilityHandlerUpdate(dt)
 						local veh = getObjectByID(vehID)
 						if veh then
 							if states.instabilityCount > 10 then
-								ui_message(""..veh:getJBeamFilename().." had too many instabilities and was deleted\n\nRight click the player's name and queue deleted vehicles to respawn it", 10, 'instabilityDelete'..veh:getJBeamFilename()..''.. vehID, "warning")
+								ui_message(""..veh:getJBeamFilename().." had too many instabilities and was deleted\n\nRight click the player's name and queue deleted vehicles to respawn it", 20, 'instabilityDelete'..veh:getJBeamFilename()..''.. vehID, "warning")
 								veh:delete()
 								vehicleInstabilityState[vehID] = nil --TODO put in spawn queue instead of clearing it
 							else

--- a/settings/mp_defaults.json
+++ b/settings/mp_defaults.json
@@ -23,7 +23,6 @@
   "showBlobDeleted"             : [ "cloud", true ],
   "autoSyncVehicles"            : [ "local", true ],
   "simplifyRemoteVehicles"      : [ "local" ],
-  "disableInstabilityPausing"   : [ "cloud", true ],
   "showSpectators"              : [ "cloud", true ],
   "showDebugOutput"             : [ "local" ],
   "enableNewChatMenu"           : [ "cloud", false ],

--- a/ui/ui-vue/src/modules/options/runtime/layout.json
+++ b/ui/ui-vue/src/modules/options/runtime/layout.json
@@ -4679,31 +4679,6 @@
         },
         {
           "version": "0.38",
-          "label": "ui.options.beammp.disableInstabilityPausing",
-          "tooltip": "ui.options.beammp.disableInstabilityPausing.tooltip",
-          "setting": "disableInstabilityPausing",
-          "interactive": true,
-          "condition_always_off": false,
-          "condition_not_shipping": false,
-          "condition_simplemenu": "",
-          "condition_visible": "",
-          "condition_enabled": "",
-          "itemType": "checkbox",
-          "component": "OptionsCheckbox",
-          "separateLabel": true,
-          "lua": "",
-          "luaOff": "",
-          "valueOn": true,
-          "valueOff": false,
-          "search": [
-            "label",
-            "caption",
-            "tooltip",
-            "setting"
-          ]
-        },
-        {
-          "version": "0.38",
           "label": "ui.options.beammp.enablePosSmoother",
           "tooltip": "ui.options.beammp.enablePosSmoother.tooltip",
           "setting": "enablePosSmoother",


### PR DESCRIPTION
Fixes vehicles turning to just props after an instability

first instability is handled with a reset like how it used to be,
if there is 4 in less than 4 seconds the vehicle is pooled/disabled for a bit,
if it continues to instability to a total of 10 times it gets deleted,
Deletion can be disabled by calling beammp_multiplayer.disableInstabilityDeletion()